### PR TITLE
Integrate with Approval Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'topological_inventory-api-client', :git => "https://github.com/mkanoor/topological_inventory-api-client", :branch => "master"
 
+gem 'approval_api_client', :git => "https://github.com/hsong-rh/approval_api_ruby_client", :branch => "master"
 #
 # Custom Gemfile modifications
 #

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -46,7 +46,7 @@ module Api
       end
 
       def submit_order
-        render json: CreateApprovalRequest.new(:params => params, :request => request).process.to_hash
+        render :json => CreateApprovalRequest.new(:params => params, :request => request).process.to_hash
       end
 
       def fetch_plans_with_portfolio_item_id

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -46,7 +46,7 @@ module Api
       end
 
       def submit_order
-        render json: SubmitOrder.new(params).process.to_hash
+        render json: CreateApprovalRequest.new(:params => params, :request => request).process.to_hash
       end
 
       def fetch_plans_with_portfolio_item_id

--- a/app/services/approval_service_api.rb
+++ b/app/services/approval_service_api.rb
@@ -1,0 +1,25 @@
+require 'approval_api_client'
+
+class ApprovalServiceApi
+  attr_reader :params
+  attr_reader :api_instance
+  attr_reader :request
+
+  def initialize(options)
+    @params = options[:params]
+    @request = options[:request]
+    ApprovalAPIClient.configure do |config|
+      config.host     = ENV['APPROVAL_SERVICE_URL']
+      config.scheme   = URI.parse(ENV['APPROVAL_SERVICE_URL']).try(:scheme)
+    end
+    @api_instance = ApprovalAPIClient::UsersApi.new
+    set_identity_header
+  end
+
+  def set_identity_header
+    x_rh = {
+      'x-rh-auth-identity' => request.headers['x-rh-auth-identity']
+    }
+    api_instance.api_client.default_headers.merge!(x_rh)
+  end
+end

--- a/app/services/create_approval_request.rb
+++ b/app/services/create_approval_request.rb
@@ -3,7 +3,7 @@ class CreateApprovalRequest < ApprovalServiceApi
     order.order_items.each do |order_item|
       submit_approval_request(order_item)
     end
-    order.update(:state => 'Ordered', :ordered_at => DateTime.now.utc)
+    order.update(:state => 'Ordered', :ordered_at => Time.now.utc)
     order
   rescue StandardError => e
     Rails.logger.error("CreateApprovalRequest #{e.message}")

--- a/app/services/create_approval_request.rb
+++ b/app/services/create_approval_request.rb
@@ -1,0 +1,51 @@
+class CreateApprovalRequest < ApprovalServiceApi
+  def process
+    order.order_items.each do |order_item|
+      submit_approval_request(order_item)
+    end
+    order.update(:state => 'Ordered', :ordered_at => DateTime.now.utc)
+    order
+  rescue StandardError => e
+    Rails.logger.error("CreateApprovalRequest #{e.message}")
+    raise
+  end
+
+  private
+
+  def submit_approval_request(order_item)
+    pf_item = portfolio_item(order_item)
+    body = request_body(pf_item, order_item)
+    begin
+      request = api_instance.add_request(pf_item.approval_workflow_ref, body)
+      order_item.approval_request_ref = request.id
+      order_item.save!
+    rescue ApprovalAPIClient::ApiError => e
+      Rails.logger.error("UsersApi->add_request #{e.message}")
+      raise
+    end
+  end
+
+  def order
+    @order ||= Order.find_by!(:id => params[:order_id])
+  end
+
+  def portfolio_item(order_item)
+    PortfolioItem.find_by!(:id => order_item.portfolio_item_id)
+  end
+
+  def request_body(pf_item, order_item)
+    o_params = ActionController::Parameters.new('order_item_id' => order_item.id)
+    content = OrderItemSanitizedParameters.new(o_params).process
+    ApprovalAPIClient::Request.new(
+      'requester' => username,
+      'name'      => pf_item.name,
+      'content'   => content.to_json
+    )
+  end
+
+  def username
+    raise "Missing Header x-rh-auth-identity" unless request.headers.key?('x-rh-auth-identity')
+    x_rh_auth_identity = JSON.parse(Base64.decode64(request.headers['x-rh-auth-identity']))
+    x_rh_auth_identity.key?('identity') ? x_rh_auth_identity['identity'].fetch('username', "unknown") : "unknown"
+  end
+end

--- a/app/services/create_approval_request.rb
+++ b/app/services/create_approval_request.rb
@@ -26,11 +26,11 @@ class CreateApprovalRequest < ApprovalServiceApi
   end
 
   def order
-    @order ||= Order.find_by!(:id => params[:order_id])
+    @order ||= Order.find(params[:order_id])
   end
 
   def portfolio_item(order_item)
-    PortfolioItem.find_by!(:id => order_item.portfolio_item_id)
+    PortfolioItem.find(order_item.portfolio_item_id)
   end
 
   def request_body(pf_item, order_item)

--- a/app/services/order_item_sanitized_parameters.rb
+++ b/app/services/order_item_sanitized_parameters.rb
@@ -1,0 +1,46 @@
+class OrderItemSanitizedParameters < TopologyServiceApi
+  MASKED_VALUE = "********".freeze
+
+  def process
+    sanitized_parameters
+  rescue StandardError => e
+    Rails.logger.error("OrderItemSanitizedParameters #{e.message}")
+    raise
+  end
+
+  private
+
+  def order_item
+    @order_item ||= OrderItem.find_by!(:id => params[:order_item_id])
+  end
+
+  def service_plan_ref
+    order_item.service_plan_ref
+  end
+
+  def service_parameters
+    order_item.service_parameters
+  end
+
+  def service_plan_schema
+    plan = api_instance.show_service_plan(service_plan_ref)
+    plan.create_json_schema
+  rescue TopologicalInventoryApiClient::ApiError => e
+    Rails.logger.error("DefaultApi->show_service_plan #{e.message}")
+    raise
+  end
+
+  def sanitized_parameters
+    svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
+    service_plan_schema[:properties].each_with_object({}) do |(key, attrs), result|
+      value = hide?(key, attrs) ? MASKED_VALUE : svc_params[key]
+      result[attrs[:title]] = value
+    end
+  end
+
+  def hide?(key, attrs)
+    attrs[:format] == "password" ||
+      /password/i.match?(attrs[:title]) ||
+      /password/i.match?(key)
+  end
+end

--- a/app/services/order_item_sanitized_parameters.rb
+++ b/app/services/order_item_sanitized_parameters.rb
@@ -11,7 +11,7 @@ class OrderItemSanitizedParameters < TopologyServiceApi
   private
 
   def order_item
-    @order_item ||= OrderItem.find_by!(:id => params[:order_item_id])
+    @order_item ||= OrderItem.find(params[:order_item_id])
   end
 
   def service_plan_ref

--- a/db/migrate/20181105223533_add_approval_request_ref_to_order_items.rb
+++ b/db/migrate/20181105223533_add_approval_request_ref_to_order_items.rb
@@ -1,0 +1,5 @@
+class AddApprovalRequestRefToOrderItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :order_items, :approval_request_ref, :string
+  end
+end

--- a/db/migrate/20181105223815_add_approval_workflow_ref_to_portfolio_items.rb
+++ b/db/migrate/20181105223815_add_approval_workflow_ref_to_portfolio_items.rb
@@ -1,0 +1,5 @@
+class AddApprovalWorkflowRefToPortfolioItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :portfolio_items, :approval_workflow_ref, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181101134526) do
+ActiveRecord::Schema.define(version: 20181105223815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20181101134526) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
+    t.string "approval_request_ref"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end
 
@@ -54,6 +55,7 @@ ActiveRecord::Schema.define(version: 20181101134526) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.string "service_offering_ref"
+    t.string "approval_workflow_ref"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end
 

--- a/spec/services/create_approval_request_spec.rb
+++ b/spec/services/create_approval_request_spec.rb
@@ -1,0 +1,76 @@
+describe CreateApprovalRequest do
+  include ServiceSpecHelper
+
+  let(:car) do
+    with_modified_env APPROVAL_SERVICE_URL: 'http://www.example.com' do
+      CreateApprovalRequest.new(:params => params, :request => request)
+    end
+  end
+
+  let(:identity) do
+    {'identity' => {'is_org_admin' => true, 'username' => 'Freddy Kreuger'} }
+  end
+
+  let(:request) do
+    ActionDispatch::TestRequest.new({}).tap do |obj|
+      obj.headers['x-rh-auth-identity'] = Base64.encode64(identity.to_json)
+    end
+  end
+
+  let(:oisp) { instance_double("OrderItemSanitizedParameters") }
+  let(:api_instance) { double(:api_instance) }
+
+  let(:approval_request) { instance_double("ApprovalAPIClient::Request", :id => "900") }
+  let(:approval_workflow_ref) { "998" }
+  let(:service_offering_ref) { "999" }
+  let(:service_plan_ref) { "777" }
+  let(:order) { create(:order) }
+  let!(:order_item) do
+    create(:order_item, :portfolio_item_id           => portfolio_item.id,
+                        :order_id                    => order.id,
+                        :service_plan_ref            => service_plan_ref,
+                        :service_parameters          => { 'b' => 1 },
+                        :provider_control_parameters => { 'a' => 1 },
+                        :count                       => 1)
+  end
+  let(:portfolio_item) do
+    create(:portfolio_item, :service_offering_ref  => service_offering_ref,
+                            :approval_workflow_ref => approval_workflow_ref)
+  end
+  let(:portfolio_item_id) { portfolio_item.id.to_s }
+  let(:params) do
+    ActionController::Parameters.new('order_id' => order.id.to_s)
+  end
+
+  before do
+    allow(car).to receive(:api_instance).and_return(api_instance)
+    allow(OrderItemSanitizedParameters).to receive(:new).and_return(oisp)
+    allow(oisp).to receive(:process).and_return('a' => 1)
+  end
+
+  context "#process" do
+    it "success scenario" do
+      allow(api_instance).to receive(:add_request) do |ref, obj|
+        expect(ref).to eq(portfolio_item.approval_workflow_ref)
+        expect(obj.name).to eq(portfolio_item.name)
+      end.and_return(approval_request)
+
+      car.process
+    end
+
+    it "failure scenario" do
+      allow(api_instance).to receive(:add_request)
+        .and_raise(ApprovalAPIClient::ApiError.new("Kaboom"))
+
+      expect { car.process }.to raise_error(StandardError)
+    end
+  end
+
+  context "missing header" do
+    let(:request) { ActionDispatch::TestRequest.new({}) }
+
+    it "raises exception" do
+      expect { car.process }.to raise_error(StandardError, /x-rh-auth-identity/)
+    end
+  end
+end

--- a/spec/services/create_approval_request_spec.rb
+++ b/spec/services/create_approval_request_spec.rb
@@ -2,7 +2,7 @@ describe CreateApprovalRequest do
   include ServiceSpecHelper
 
   let(:car) do
-    with_modified_env APPROVAL_SERVICE_URL: 'http://www.example.com' do
+    with_modified_env :APPROVAL_SERVICE_URL => 'http://www.example.com' do
       CreateApprovalRequest.new(:params => params, :request => request)
     end
   end

--- a/spec/services/create_approval_request_spec.rb
+++ b/spec/services/create_approval_request_spec.rb
@@ -7,13 +7,15 @@ describe CreateApprovalRequest do
     end
   end
 
+  let(:username) { "Freddy Kreuger" }
+
   let(:identity) do
-    {'identity' => {'is_org_admin' => true, 'username' => 'Freddy Kreuger'} }
+    {'identity' => {'is_org_admin' => true, 'username' => username} }
   end
 
   let(:request) do
     ActionDispatch::TestRequest.new({}).tap do |obj|
-      obj.headers['x-rh-auth-identity'] = Base64.encode64(identity.to_json)
+      obj.headers['x-rh-auth-identity'] = Base64.urlsafe_encode64(identity.to_json)
     end
   end
 
@@ -53,6 +55,7 @@ describe CreateApprovalRequest do
       allow(api_instance).to receive(:add_request) do |ref, obj|
         expect(ref).to eq(portfolio_item.approval_workflow_ref)
         expect(obj.name).to eq(portfolio_item.name)
+        expect(obj.requester).to eq(username)
       end.and_return(approval_request)
 
       car.process

--- a/spec/services/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/order_item_sanitized_parameters_spec.rb
@@ -6,7 +6,7 @@ describe OrderItemSanitizedParameters do
   let(:api_instance) { double(:api_instance) }
   let(:service_plan_ref) { "777" }
   let(:oisp) do
-    with_modified_env TOPOLOGY_SERVICE_URL: 'http://www.example.com' do
+    with_modified_env :TOPOLOGY_SERVICE_URL => 'http://www.example.com' do
       OrderItemSanitizedParameters.new(params)
     end
   end

--- a/spec/services/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/order_item_sanitized_parameters_spec.rb
@@ -1,0 +1,68 @@
+describe OrderItemSanitizedParameters do
+  include ServiceSpecHelper
+
+  Plan = Struct.new(:name, :id, :description, :create_json_schema)
+  let(:plan) { Plan.new("Plan A", "1", "Plan A", json_schema) }
+  let(:api_instance) { double(:api_instance) }
+  let(:service_plan_ref) { "777" }
+  let(:oisp) do
+    with_modified_env TOPOLOGY_SERVICE_URL: 'http://www.example.com' do
+      OrderItemSanitizedParameters.new(params)
+    end
+  end
+
+  let(:order_item) do
+    create(:order_item, :portfolio_item_id           => 100,
+                        :order_id                    => 45,
+                        :service_plan_ref            => service_plan_ref,
+                        :service_parameters          => service_parameters,
+                        :provider_control_parameters => { 'a' => 1 },
+                        :count                       => 1)
+  end
+
+  let(:json_schema) { { :properties => properties } }
+
+  let(:properties) do
+    {'user'     => {:title => 'User Name', :type => 'string'},
+     'password' => {:title => 'Secret', :type => 'string'},
+     'newpwd'   => {:title => 'Users Password', :type => 'string'},
+     'salary'   => {:title => 'Salary', :format => 'password', :type => 'number'},
+     'db_name'  => {:title => 'Database Name', :type => 'string'}}
+  end
+
+  let(:service_parameters) do
+    { 'user'     => 'Fred Flintstone',
+      'password' => 'Yabba Dabba Doo',
+      'salary'   => 10_000_000,
+      'newpwd'   => 'Yabba Dabba Two',
+      'db_name'  => 'Slate Rocking Company' }
+  end
+
+  let(:params) do
+    ActionController::Parameters.new('order_item_id' => order_item.id)
+  end
+
+  before do
+    allow(oisp).to receive(:api_instance).and_return(api_instance)
+  end
+
+  context "#process" do
+    it "success scenario" do
+      expect(api_instance).to receive(:show_service_plan)
+        .with(order_item.service_plan_ref)
+        .and_return(plan)
+
+      result = oisp.process
+
+      expect(result.values.select { |v| v == described_class::MASKED_VALUE }.count).to eq(3)
+    end
+
+    it "failure scenario" do
+      expect(api_instance).to receive(:show_service_plan)
+        .with(order_item.service_plan_ref)
+        .and_raise(TopologicalInventoryApiClient::ApiError.new("Kaboom"))
+
+      expect { oisp.process }.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
Uses the Approval API client to send approval request to
the approval service and store the request reference for each order
item. When the approval request is created it includes the name of
the portfolio item and also the parameters to be used in provisioning.
Any password parameters are masked

Needs the APPROVAL_SERVICE_URL environment variable to be setup before starting the Service Portal.