### PR TITLE
Listen for task update messages from topological-inventory-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'acts_as_tenant'
 gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'master'
 gem 'jbuilder', '~> 2.0'
 gem 'manageiq-loggers', '~> 0.1'
+gem 'manageiq-messaging', '~> 0.1.2', :require => false
 gem 'more_core_extensions', '~>3.5'
 gem 'pg', '~> 1.0', :require => false
 gem 'prometheus-client', '~> 0.8.0'

--- a/bin/service_order_listener
+++ b/bin/service_order_listener
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+require "bundler/setup"
+require "service_order_listener"
+
+queue_host = ENV["QUEUE_HOST"] || "localhost"
+queue_port = ENV["QUEUE_PORT"] || 9092
+
+service_order_listener = ServiceOrderListener.new(:host => queue_host, :port => queue_port)
+service_order_listener.run.join

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,9 +3,3 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
-
-queue_host = ENV["QUEUE_HOST"] || "localhost"
-queue_port = ENV["QUEUE_PORT"] || 9092
-
-service_order_listener = ServiceOrderListener.new(:host => queue_host, :port => queue_port)
-service_order_listener.run

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,9 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+queue_host = ENV["QUEUE_HOST"] || "localhost"
+queue_port = ENV["QUEUE_PORT"] || 9092
+
+service_order_listener = ServiceOrderListener.new(:host => queue_host, :port => queue_port)
+service_order_listener.run

--- a/config/initializers/service_order_listener.rb
+++ b/config/initializers/service_order_listener.rb
@@ -1,0 +1,7 @@
+# Be sure to restart your server when you modify this file.
+
+queue_host = ENV["QUEUE_HOST"] || "localhost"
+queue_port = ENV["QUEUE_PORT"] || 9092
+
+service_order_listener = ServiceOrderListener.new(:host => queue_host, :port => queue_port)
+service_order_listener.run

--- a/lib/service_order_listener.rb
+++ b/lib/service_order_listener.rb
@@ -1,0 +1,44 @@
+class ServiceOrderListener
+  attr_accessor :messaging_client_options, :client
+
+  def initialize(messaging_client_options = {})
+    self.messaging_client_options = default_messaing_options.merge(messaging_client_options)
+  end
+
+  def run
+    Thread.new do
+      self.client = ManageIQ::Messaging::Client.open(messaging_client_options)
+
+      client.subscribe_messages({
+        :service   => "platform.topological-inventory.task-output-stream",
+        :max_bytes => 500_000
+      }) do |messages|
+        messages.each do |msg|
+          process_message(msg)
+        end
+      end
+    end
+  ensure
+    client&.close
+    self.client = nil
+  end
+
+  private
+
+  def process_message(msg)
+    if msg.payload["state"] == "completed"
+      item = OrderItem.where(:topology_task_ref => msg.payload["task_id"]).first
+      item.state = 'Order Completed?'
+      item.update_message('info', 'Order Complete')
+      item.save!
+    end
+  end
+
+  def default_messaing_options
+    {
+      :protocol   => :Kafka,
+      :client_ref => "catalog-api-worker?",
+      :group_ref  => "catalog-api-worker?"
+    }
+  end
+end

--- a/lib/service_order_listener.rb
+++ b/lib/service_order_listener.rb
@@ -13,16 +13,18 @@ class ServiceOrderListener
   end
 
   def run
-    Thread.new do
-      self.client = ManageIQ::Messaging::Client.open(messaging_client_options)
+    Thread.new { subscribe_to_task_updates }
+  end
 
-      client.subscribe_messages(
-        :service   => SERVICE_NAME,
-        :max_bytes => 500_000
-      ) do |messages|
-        messages.each do |msg|
-          process_message(msg)
-        end
+  def subscribe_to_task_updates
+    self.client = ManageIQ::Messaging::Client.open(messaging_client_options)
+
+    client.subscribe_messages(
+      :service   => SERVICE_NAME,
+      :max_bytes => 500_000
+    ) do |messages|
+      messages.each do |msg|
+        process_message(msg)
       end
     end
   ensure
@@ -33,7 +35,7 @@ class ServiceOrderListener
   private
 
   def process_message(msg)
-    ProgressMessage.create(
+    ProgressMessage.create!(
       :level   => "info",
       :message => "Task update message received with payload: #{msg.payload}"
     )

--- a/lib/service_order_listener.rb
+++ b/lib/service_order_listener.rb
@@ -1,3 +1,5 @@
+require "manageiq-messaging"
+
 class ServiceOrderListener
   SERVICE_NAME = "platform.topological-inventory.task-output-stream".freeze
   CLIENT_AND_GROUP_REF = "catalog-api-worker".freeze
@@ -7,7 +9,7 @@ class ServiceOrderListener
   attr_accessor :messaging_client_options, :client
 
   def initialize(messaging_client_options = {})
-    self.messaging_client_options = default_messaing_options.merge(messaging_client_options)
+    self.messaging_client_options = default_messaging_options.merge(messaging_client_options)
   end
 
   def run
@@ -50,7 +52,7 @@ class ServiceOrderListener
     )
   end
 
-  def default_messaing_options
+  def default_messaging_options
     {
       :protocol   => :Kafka,
       :client_ref => CLIENT_AND_GROUP_REF,

--- a/spec/lib/service_order_listener_spec.rb
+++ b/spec/lib/service_order_listener_spec.rb
@@ -1,0 +1,41 @@
+require "manageiq-messaging"
+
+describe ServiceOrderListener do
+  let(:client) { double(:client) }
+
+  describe "#run" do
+    let(:messages) { [ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil)] }
+    let(:payload) { {"task_id" => "123", "state" => state} }
+    let!(:item) do
+      OrderItem.create!(
+        :count                       => 1,
+        :service_parameters          => "test",
+        :provider_control_parameters => "test",
+        :order                       => order,
+        :service_plan_ref            => "321",
+        :portfolio_item              => portfolio_item,
+        :topology_task_ref           => "123"
+      )
+    end
+    let(:order) { Order.create! }
+    let(:portfolio_item) { PortfolioItem.create!(:service_offering_ref => "321") }
+
+    before do
+      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      allow(client).to receive(:subscribe_messages).with(
+        :service   => "platform.topological-inventory.task-output-stream",
+        :max_bytes => 500_000
+      ).and_yield(messages)
+    end
+
+    context "when the state of the task is completed" do
+      let(:state) { "completed" }
+
+      it "updates the order item to be completed" do
+        subject.run.join
+        item.reload
+        expect(item.state).to eq("Order Completed?")
+      end
+    end
+  end
+end

--- a/spec/lib/service_order_listener_spec.rb
+++ b/spec/lib/service_order_listener_spec.rb
@@ -1,5 +1,3 @@
-require "manageiq-messaging"
-
 describe ServiceOrderListener do
   let(:client) { double(:client) }
 

--- a/spec/lib/service_order_listener_spec.rb
+++ b/spec/lib/service_order_listener_spec.rb
@@ -14,27 +14,92 @@ describe ServiceOrderListener do
         :order                       => order,
         :service_plan_ref            => "321",
         :portfolio_item              => portfolio_item,
-        :topology_task_ref           => "123"
+        :topology_task_ref           => topology_task_ref
       )
     end
     let(:order) { Order.create! }
     let(:portfolio_item) { PortfolioItem.create!(:service_offering_ref => "321") }
 
     before do
-      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      allow(ManageIQ::Messaging::Client).to receive(:open).with(
+        :protocol   => :Kafka,
+        :client_ref => ServiceOrderListener::CLIENT_AND_GROUP_REF,
+        :group_ref  => ServiceOrderListener::CLIENT_AND_GROUP_REF
+      ).and_return(client)
       allow(client).to receive(:subscribe_messages).with(
-        :service   => "platform.topological-inventory.task-output-stream",
+        :service   => ServiceOrderListener::SERVICE_NAME,
         :max_bytes => 500_000
       ).and_yield(messages)
     end
 
-    context "when the state of the task is completed" do
-      let(:state) { "completed" }
+    context "when the order item is not findable" do
+      let(:topology_task_ref) { "0" }
 
-      it "updates the order item to be completed" do
-        subject.run.join
-        item.reload
-        expect(item.state).to eq("Order Completed?")
+      context "when the state of the task is anything else" do
+        let(:state) { "test" }
+
+        it "creates a progress message about the payload" do
+          subject.run.join
+          latest_progress_message = ProgressMessage.last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+        end
+      end
+
+      context "when the state of the task is completed" do
+        let(:state) { "completed" }
+
+        it "creates a progress message about the payload" do
+          subject.run.join
+          latest_progress_message = ProgressMessage.second_to_last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+        end
+
+        it "creates a progress message with an error" do
+          subject.run.join
+          latest_progress_message = ProgressMessage.last
+          expect(latest_progress_message.level).to eq("error")
+          expect(latest_progress_message.message).to eq("Could not find OrderItem with topology_task_ref of 123")
+        end
+      end
+    end
+
+    context "when the order item is findable" do
+      let(:topology_task_ref) { "123" }
+
+      context "when the state of the task is anything else" do
+        let(:state) { "test" }
+
+        it "creates a progress message about the payload" do
+          subject.run.join
+          latest_progress_message = ProgressMessage.last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+        end
+
+        it "does not update the order" do
+          subject.run.join
+          item.reload
+          expect(item.state).to eq("Created")
+        end
+      end
+
+      context "when the state of the task is completed" do
+        let(:state) { "completed" }
+
+        it "creates a progress message about the payload" do
+          subject.run.join
+          latest_progress_message = ProgressMessage.second_to_last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+        end
+
+        it "updates the order item to be completed" do
+          subject.run.join
+          item.reload
+          expect(item.state).to eq("Order Completed")
+        end
       end
     end
   end


### PR DESCRIPTION
~~@mkanoor Is this kind of what you were thinking of? I think the threading part should work as-is, but obviously something like Sidekiq would obfuscate away a bit of the "retry" stuff here. The main issue is how long do we retry for, what's the retry interval, etc.~~

~~I'm guessing you also would like `ProgressMessage`s to be interspersed in here as well? I think that could probably be a separate PR since it seems similar to doing something like adding logging.~~

~~Perhaps most importantly, I'm not quite sure what to do with the result from the external API, both the `source_id` and the `source_ref`.~~

Updated to now create a new thread on boot which delegates to a listener for messages.