### PR TITLE
Add 'context' column to OrderItem

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -38,6 +38,7 @@ class OrderItem < ApplicationRecord
 
   def set_defaults
     self.state = "Created"
+    self.context = ManageIQ::API::Common::Request.current.to_h
   end
 
   def update_message(level, message)

--- a/db/migrate/20190307171244_add_context_to_order_item.rb
+++ b/db/migrate/20190307171244_add_context_to_order_item.rb
@@ -1,0 +1,5 @@
+class AddContextToOrderItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_items, :context, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_204110) do
+ActiveRecord::Schema.define(version: 2019_03_07_171244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_02_19_204110) do
     t.bigint "portfolio_item_id"
     t.jsonb "service_parameters"
     t.jsonb "provider_control_parameters"
+    t.jsonb "context"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-93

This PR adds a context column to the OderItem model so that we can store the incoming request when the order is submitted, headers and all.

This PR is still a WIP due to the fact that I haven't added tests, but now that the new header stuff is merged I should be able to get them added. 