### PR TITLE
Add Icon PortfolioItem subresource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'maste
 gem 'jbuilder', '~> 2.0'
 gem 'manageiq-loggers', '~> 0.1'
 gem 'manageiq-messaging', '~> 0.1.2', :require => false
+gem 'mimemagic', '~> 0.3.3'
 gem 'more_core_extensions', '~>3.5'
 gem 'pg', '~> 1.0', :require => false
 gem 'prometheus-client', '~> 0.8.0'

--- a/app/controllers/api/v0x1/icon_controller.rb
+++ b/app/controllers/api/v0x1/icon_controller.rb
@@ -6,7 +6,10 @@ module Api
       def index
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
         so = ServiceOffering::Icons.new(portfolio_item.service_offering_icon_ref)
-        render :json => so.process.icon
+        icon = so.process.icon
+        send_data(icon.data,
+                  :type        => MimeMagic.by_magic(icon.data).type,
+                  :disposition => 'inline')
       rescue ActiveRecord::RecordNotFound => e
         render :json => { :message => e.message }, :status => :not_found
       rescue ArgumentError

--- a/app/controllers/api/v0x1/icon_controller.rb
+++ b/app/controllers/api/v0x1/icon_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V0x1
+    class IconController < ApplicationController
+      include Api::V0x1::Mixins::IndexMixin
+
+      def index
+        portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
+        so = ServiceOffering::Icons.new(portfolio_item.service_offering_icon_ref)
+        render :json => so.process.icon
+      rescue ActiveRecord::RecordNotFound => e
+        render :json => { :message => e.message }, :status => :not_found
+      rescue ArgumentError
+        render :json => { :message => "Icon ID not present on Portfolio Item" }, :status => :not_found
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x0/icon_controller.rb
+++ b/app/controllers/api/v1x0/icon_controller.rb
@@ -1,9 +1,9 @@
 module Api
-  module V0x1
+  module V1x0
     class IconController < ApplicationController
-      include Api::V0x1::Mixins::IndexMixin
+      include Api::V1x0::Mixins::IndexMixin
 
-      def index
+      def show
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
         so = ServiceOffering::Icons.new(portfolio_item.service_offering_icon_ref)
         icon = so.process.icon

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -41,6 +41,7 @@ module ServiceOffering
     # If certain fields are empty populate them from the other fields that we do have.
     def populate_missing_fields
       @params[:service_offering_source_ref] = @service_offering.source_id
+      @params[:service_offering_icon_ref] = @service_offering.service_offering_icon_id
       # Fill up empty fields if they're empty with fields we already have, this is really easy with the ||= and subsequent || operators
       @params[:long_description] ||= @params[:description] || @params[:display_name]
       @params[:display_name] ||= @params[:name]

--- a/app/services/service_offering/icons.rb
+++ b/app/services/service_offering/icons.rb
@@ -1,0 +1,21 @@
+module ServiceOffering
+  class Icons
+    attr_reader :icon_id
+    attr_reader :icon
+
+    def initialize(id)
+      @icon_id = id.to_s
+    end
+
+    def process
+      TopologicalInventory.call do |api_instance|
+        @icon = api_instance.show_service_offering_icon(@icon_id)
+      end
+
+      self
+    rescue StandardError => e
+      Rails.logger.error("Portfolio Item Icons ID #{@icon_id}: #{e.message}")
+      raise
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]
         resources :service_plans,               :only => [:index]
+        resources :icon,                        :only => [:index]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]
         resources :service_plans,               :only => [:index]
-        resources :icon,                        :only => [:index]
+        get :icon, :action => 'show', :controller => 'icon'
       end
     end
   end

--- a/db/migrate/20190206213630_add_icon_column_to_portfolioitem.rb
+++ b/db/migrate/20190206213630_add_icon_column_to_portfolioitem.rb
@@ -1,5 +1,5 @@
 class AddIconColumnToPortfolioitem < ActiveRecord::Migration[5.2]
   def change
-    add_column :portfolio_items, :service_offering_icon_ref, :bigint
+    add_column :portfolio_items, :service_offering_icon_ref, :string
   end
 end

--- a/db/migrate/20190206213630_add_icon_column_to_portfolioitem.rb
+++ b/db/migrate/20190206213630_add_icon_column_to_portfolioitem.rb
@@ -1,0 +1,5 @@
+class AddIconColumnToPortfolioitem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :portfolio_items, :service_offering_icon_ref, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_184014) do
     t.datetime "discarded_at"
     t.string "workflow_ref"
     t.string "owner"
-    t.bigint "service_offering_icon_ref"
+    t.string "service_offering_icon_ref"
     t.index ["discarded_at"], name: "index_portfolio_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_184014) do
     t.datetime "discarded_at"
     t.string "workflow_ref"
     t.string "owner"
+    t.bigint "service_offering_icon_ref"
     t.index ["discarded_at"], name: "index_portfolio_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -980,8 +980,7 @@
     "/portfolio_items/{portfolio_item_id}/icon": {
       "get": {
         "tags": [
-          "users",
-          "admins"
+          "PortfolioItem"
         ],
         "summary": "Fetches the specified portfolio item's icon information",
         "operationId": "listServiceOfferingIcon",
@@ -1178,7 +1177,7 @@
             "example": "jdoe"
           },
           "service_offering_icon_ref": {
-              "type": "integer",
+              "type": "string",
               "readOnly": true,
               "title": "Service Offering Icon Ref",
               "example": 20
@@ -1473,7 +1472,7 @@
          "id": {
            "type": "string",
            "title": "ID",
-           "description": "The unique identifier for this Service Plan",
+           "description": "The unique identifier for this Service Offering Icon",
            "readOnly": true
          },
          "data": {

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -976,6 +976,46 @@
           }
         }
       }
+    },
+    "/portfolio_items/{portfolio_item_id}/icon": {
+      "get": {
+        "tags": [
+          "users",
+          "admins"
+        ],
+        "summary": "Fetches the specified portfolio item's icon information",
+        "operationId": "listServiceOfferingIcon",
+        "description": "Fetch the specified portfolio item's icon information.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Item Icon",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceOfferingIcon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Icon Not Found/Not Present on Portfolio Item"
+          },
+          "500": {
+            "description": "Could not access the Topology Service"
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -1136,6 +1176,12 @@
             "type": "string",
             "title": "Owner",
             "example": "jdoe"
+          },
+          "service_offering_icon_ref": {
+              "type": "integer",
+              "readOnly": true,
+              "title": "Service Offering Icon Ref",
+              "example": 20
           }
         }
       },
@@ -1421,6 +1467,29 @@
           }
         }
       },
+      "ServiceOfferingIcon": {
+       "type": "object",
+       "properties": {
+         "id": {
+           "type": "string",
+           "title": "ID",
+           "description": "The unique identifier for this Service Plan",
+           "readOnly": true
+         },
+         "data": {
+           "type": "string",
+           "title": "Data",
+           "description": "The raw SVG data for this icon",
+           "readOnly": false
+         },
+         "source_ref": {
+           "type": "string",
+           "title": "Source Ref",
+           "description": "Stores the Source Ref for this icon",
+           "readOnly": true
+         }
+       }
+     },
       "ProgressMessage": {
         "type": "object",
         "properties": {

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -230,7 +230,7 @@ describe "PortfolioItemRequests", :type => :request do
       it "reaches out to topology to get the icon" do
         expect(api_instance).to receive(:show_service_offering_icon).with(topology_service_offering_icon.id.to_s).and_return(topology_service_offering_icon)
 
-        get "#{api('0.1')}/portfolio_items/#{portfolio_item_without_overriden_icon.id}/icon", :headers => admin_headers
+        get "#{api}/portfolio_items/#{portfolio_item_without_overriden_icon.id}/icon", :headers => admin_headers
 
         expect(response).to have_http_status(200)
         expect(response.content_type).to eq "image/svg+xml"

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -7,10 +7,12 @@ describe "PortfolioItemRequests", :type => :request do
 
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }
-  let(:order)                { create(:order) }
-  let(:portfolio_item)       do
+  let(:order) { create(:order) }
+  let(:icon_id) { 1 }
+  let(:portfolio_item) do
     create(:portfolio_item, :service_offering_ref        => service_offering_ref,
-                            :service_offering_source_ref => service_offering_source_ref)
+                            :service_offering_source_ref => service_offering_source_ref,
+                            :service_offering_icon_ref   => icon_id)
   end
   let(:portfolio_item_id)    { portfolio_item.id }
   let(:topo_ex)              { Catalog::TopologyError.new("kaboom") }
@@ -198,6 +200,40 @@ describe "PortfolioItemRequests", :type => :request do
 
       it "does not update the read-only field" do
         expect(json["service_offering_ref"]).to_not eq invalid_attributes[:service_offering_ref]
+      end
+    end
+  end
+
+  context "icons" do
+    let(:api_instance) { double }
+    let(:topological_inventory) do
+      class_double("TopologicalInventory")
+        .as_stubbed_const(:transfer_nested_constants => true)
+    end
+
+    let(:topology_service_offering_icon) do
+      TopologicalInventoryApiClient::ServiceOfferingIcon.new(
+        :id         => icon_id,
+        :source_ref => "src",
+        :data       => "img"
+      )
+    end
+    let(:portfolio_item_without_overriden_icon) do
+      create(:portfolio_item,
+             :service_offering_icon_ref => topology_service_offering_icon.id)
+    end
+
+    before do
+      allow(topological_inventory).to receive(:call).and_yield(api_instance)
+    end
+    context "when we have to hit topology for the icon data" do
+      it "reaches out to topology to get the icon" do
+        expect(api_instance).to receive(:show_service_offering_icon).with(topology_service_offering_icon.id.to_s).and_return(topology_service_offering_icon)
+
+        get "#{api('0.1')}/portfolio_items/#{portfolio_item_without_overriden_icon.id}/icon", :headers => admin_headers
+
+        expect(response).to have_http_status(200)
+        expect(json["id"]).to eq topology_service_offering_icon.id
       end
     end
   end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -213,9 +213,9 @@ describe "PortfolioItemRequests", :type => :request do
 
     let(:topology_service_offering_icon) do
       TopologicalInventoryApiClient::ServiceOfferingIcon.new(
-        :id         => icon_id,
+        :id         => icon_id.to_s,
         :source_ref => "src",
-        :data       => "img"
+        :data       => "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><defs><style>.cls-1{fill:#d71e00}.cls-2{fill:#c21a00}.cls-3{fill:#fff}.cls-4{fill:#eaeaea}</style></defs><title>Logo</title><g id=\"Layer_1\" data-name=\"Layer 1\"><circle class=\"cls-1\" cx=\"50\" cy=\"50\" r=\"50\" transform=\"rotate(-45 50 50)\"/><path class=\"cls-2\" d=\"M85.36 14.64a50 50 0 0 1-70.72 70.72z\"/><path d=\"M31 31.36a1.94 1.94 0 0 1-3.62-.89.43.43 0 0 1 .53-.44 3.32 3.32 0 0 0 2.81.7.43.43 0 0 1 .28.63z\"/><path class=\"cls-3\" d=\"M77.63 44.76C77.12 41.34 73 21 66.32 21c-2.44 0-4.59 3.35-6 6.88-.44 1.06-1.23 1.08-1.63 0-1.45-3.72-2.81-6.88-5.41-6.88-9.94 0-5.44 24.18-14.28 24.18-4.57 0-5.37-10.59-5.5-14.72 2.19.65 3.3-1 3.55-2.61a.63.63 0 0 0-.48-.72 3.36 3.36 0 0 0-3 .89h-6.26a1 1 0 0 0-.68.28l-.53.53h-3.89a.54.54 0 0 0-.38.16l-3.95 3.95a.54.54 0 0 0 .38.91h11.45c.6 6.26 1.75 22 16.42 17.19l-.32 5-1.44 22.42a1 1 0 0 0 1 1h4.9a1 1 0 0 0 1-1l-.61-23.33-.15-5.81c6-2.78 9-5.66 16.19-6.75-1.59 2.62-2.05 6.87-2.06 8-.06 6 2.55 8.74 5 13.22L63.73 78a1 1 0 0 0 .89 1.32h4.64a1 1 0 0 0 .93-.74L74 62.6c-4.83-7.43 1.83-15.31 3.41-17a1 1 0 0 0 .22-.84zM31 31.36a1.94 1.94 0 0 1-3.62-.89.43.43 0 0 1 .53-.44 3.32 3.32 0 0 0 2.81.7.43.43 0 0 1 .28.63z\"/><path class=\"cls-4\" d=\"M46.13 51.07c-14.67 4.85-15.82-10.93-16.42-17.19H18.65l2.1 2.12a1 1 0 0 0 .68.28h6c0 5.8 1.13 20.2 14 20.2a31.34 31.34 0 0 0 4.42-.35zM50.41 49.36l.15 5.81a108.2 108.2 0 0 0 14-4.54 19.79 19.79 0 0 1 2.06-8c-7.16 1.07-10.18 3.95-16.21 6.73z\"/></g></svg>"
       )
     end
     let(:portfolio_item_without_overriden_icon) do
@@ -233,7 +233,7 @@ describe "PortfolioItemRequests", :type => :request do
         get "#{api('0.1')}/portfolio_items/#{portfolio_item_without_overriden_icon.id}/icon", :headers => admin_headers
 
         expect(response).to have_http_status(200)
-        expect(json["id"]).to eq topology_service_offering_icon.id
+        expect(response.content_type).to eq "image/svg+xml"
       end
     end
   end

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -41,8 +41,8 @@ describe ServiceOffering::AddToPortfolioItem do
     it "#{described_class}#populate_missing_fields(params)" do
       my_params = add_to_portfolio_item.send(:populate_missing_fields)
 
-      # It should have added the extra field (source ref) as well as inferring the values of long_description and display name, giving us 5 total fields.
-      expect(my_params.keys.size).to eql 5
+      # It should have added the extra field (source ref) as well as inferring the values of long_description and display name, giving us 6 total fields.
+      expect(my_params.keys.size).to eql 6
       expect(my_params[:long_description]).to eq(params[:description])
       expect(my_params[:display_name]).to eq(params[:name])
     end

--- a/spec/support/service_offering_topological_service_offering_helper.rb
+++ b/spec/support/service_offering_topological_service_offering_helper.rb
@@ -1,16 +1,17 @@
 module ServiceOfferingHelper
   def fully_populated_service_offering
     TopologicalInventoryApiClient::ServiceOffering.new(
-      :id                => 1,
-      :name              => "test name",
-      :description       => "test description",
-      :source_ref        => '123',
-      :source_id         => '45',
-      :display_name      => "test display name",
-      :long_description  => "test long description",
-      :documentation_url => "http://test.docs.io",
-      :support_url       => "800-555-TEST",
-      :distributor       => "Red Hat Inc."
+      :id                       => 1,
+      :name                     => "test name",
+      :description              => "test description",
+      :source_ref               => '123',
+      :source_id                => '45',
+      :display_name             => "test display name",
+      :long_description         => "test long description",
+      :documentation_url        => "http://test.docs.io",
+      :support_url              => "800-555-TEST",
+      :distributor              => "Red Hat Inc.",
+      :service_offering_icon_id => 998
     )
   end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-129

_**THIS PR IS A CLEANUP OF THIS PR: https://github.com/ManageIQ/catalog-api/pull/112**_


This PR adds support for retrieving icons through the service portal API. It is a pass through for the topology icons service (in the future, if there is no overridden icon in the service portal database we will return that instead). The meat of reaching out to Topology for the icon is in ServiceOffering::Icons

It provides the following new subresource:

GET /portfolio_items/{portfolio_item_id}/icon

