### PR TITLE
Add workflow_ref to PortfolioItem CRUD

### DIFF
--- a/app/controllers/api/v0x1/portfolio_items_controller.rb
+++ b/app/controllers/api/v0x1/portfolio_items_controller.rb
@@ -37,11 +37,11 @@ module Api
       private
 
       def portfolio_item_params
-        params.permit(:service_offering_ref)
+        params.permit(:service_offering_ref, :workflow_ref)
       end
 
       def portfolio_item_patch_params
-        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url)
+        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref)
       end
     end
   end

--- a/db/migrate/20190312200721_add_workflow_ref_to_portfolio_item.rb
+++ b/db/migrate/20190312200721_add_workflow_ref_to_portfolio_item.rb
@@ -1,0 +1,5 @@
+class AddWorkflowRefToPortfolioItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :portfolio_items, :workflow_ref, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_07_171244) do
+ActiveRecord::Schema.define(version: 2019_03_12_200721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2019_03_07_171244) do
     t.string "documentation_url"
     t.string "support_url"
     t.datetime "discarded_at"
+    t.string "workflow_ref"
     t.index ["discarded_at"], name: "index_portfolio_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end

--- a/public/catalog/v0.1.0/openapi.json
+++ b/public/catalog/v0.1.0/openapi.json
@@ -1045,6 +1045,11 @@
             "readOnly": true,
             "title": "Support URL",
             "example": "The URL for finding support for the portfolio item"
+          },
+          "workflow_ref": {
+            "type": "string",
+            "title": "Approval Workflow ID",
+            "example": "The approval workflow selected for a portfolio item"
           }
         }
       },

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -252,7 +252,7 @@ describe "PortfolioItemRequests", :type => :request do
   end
 
   describe "patching portfolio items" do
-    let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'PatchDescription' } }
+    let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'PatchDescription', :workflow_ref => 'PatchWorkflowRef'} }
     let(:invalid_attributes) { { :name => 'PatchPortfolio', :service_offering_ref => "27" } }
 
     context "when passing in valid attributes" do
@@ -265,8 +265,7 @@ describe "PortfolioItemRequests", :type => :request do
       end
 
       it 'patches the record' do
-        expect(json["name"]).to eq valid_attributes[:name]
-        expect(json["description"]).to eq valid_attributes[:description]
+        expect(json).to include(valid_attributes.stringify_keys)
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-38

This PR adds `workflow_ref` as a field on `PortfolioItem` and appropriate CRUD operations. More logic to appropriately determine approval status will be added in another PR.