### PR TITLE
Update Rails/ActiveRecord Version to 5.2.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem 'rails', '~> 5.2.2'
+gem 'rails', '>= 5.2.2.1', '~> 5.2.2'
 
 group :development, :test do
   gem 'byebug', platform: :mri


### PR DESCRIPTION
Bumping the Rails version in the Gemfile due to CVE-2019-5418.

https://groups.google.com/forum/#!forum/rubyonrails-security