### PR TITLE
Modify as_json serializer to handle time and id strings.

### DIFF
--- a/config/initializers/application_record_serializing.rb
+++ b/config/initializers/application_record_serializing.rb
@@ -1,0 +1,1 @@
+ApplicationRecord.prepend(OpenApi::Serializer)

--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -1,0 +1,14 @@
+module OpenApi
+  module Serializer
+    def as_json(arg = {})
+      return super unless kind_of?(ApplicationRecord)
+
+      super.tap do |hash|
+        hash.each_key do |attr_key|
+          hash[attr_key] = hash[attr_key].iso8601 if hash[attr_key].kind_of?(Time)
+          hash[attr_key] = hash[attr_key].to_s if attr_key.ends_with?("_id") || attr_key == "id"
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ApplicationController, :type => :request do
       get("/api/v0.0/portfolios/#{portfolio_id}", :headers => headers)
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to include("id" => portfolio_id)
+      expect(response.parsed_body).to include("id" => portfolio_id.to_s)
     end
 
     it "get /portfolios without tenant" do

--- a/spec/lib/open_api/serializer_spec.rb
+++ b/spec/lib/open_api/serializer_spec.rb
@@ -1,0 +1,21 @@
+describe OpenApi::Serializer do
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => create(:portfolio)) }
+
+  it "converts id columns to strings" do
+    expect(portfolio_item.as_json).to include(
+      'id'           => portfolio_item.id.to_s,
+      'portfolio_id' => portfolio_item.portfolio.id.to_s
+    )
+  end
+
+  it "converts Time columns to iso8601" do
+    expect(portfolio_item.as_json).to include(
+      'created_at' => portfolio_item.created_at.iso8601,
+      'updated_at' => portfolio_item.updated_at.iso8601,
+    )
+  end
+
+  it 'excludes properties with nil values' do
+    expect(portfolio_item.as_json.keys).to_not include('archived_at')
+  end
+end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -23,7 +23,7 @@ describe "PortfolioItemRequests", :type => :request do
         end
 
         it 'returns the portfolio_item we asked for' do
-          expect(json["id"]).to eq portfolio_item.id
+          expect(json["id"]).to eq portfolio_item.id.to_s
         end
       end
     end
@@ -41,7 +41,7 @@ describe "PortfolioItemRequests", :type => :request do
         end
 
         it 'returns the portfolio_item we asked for' do
-          expect(json["id"]).to eq portfolio_item.id
+          expect(json["id"]).to eq portfolio_item.id.to_s
         end
       end
     end
@@ -121,7 +121,7 @@ describe "PortfolioItemRequests", :type => :request do
 
       post "#{api}/portfolio_items", :params => params
       expect(response).to have_http_status(:ok)
-      expect(json["id"]).to eq portfolio_item.id
+      expect(json["id"]).to eq portfolio_item.id.to_s
       expect(json["service_offering_ref"]).to eq service_offering_ref
     end
   end
@@ -147,7 +147,7 @@ describe "PortfolioItemRequests", :type => :request do
 
       post "#{api('0.1')}/portfolio_items", :params => params
       expect(response).to have_http_status(:ok)
-      expect(json["id"]).to eq portfolio_item.id
+      expect(json["id"]).to eq portfolio_item.id.to_s
       expect(json["service_offering_ref"]).to eq service_offering_ref
     end
   end

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -22,7 +22,7 @@ describe 'Portfolios API' do
 
         it 'returns portfolio requested' do
           expect(json).not_to be_empty
-          expect(json['id']).to eq(portfolio_id)
+          expect(json['id']).to eq(portfolio_id.to_s)
         end
       end
     end
@@ -39,7 +39,7 @@ describe 'Portfolios API' do
 
         it 'returns portfolio requested' do
           expect(json).not_to be_empty
-          expect(json['id']).to eq(portfolio_id)
+          expect(json['id']).to eq(portfolio_id.to_s)
         end
       end
     end
@@ -52,7 +52,7 @@ describe 'Portfolios API' do
       it 'returns all associated portfolio_items' do
         expect(json).not_to be_empty
         expect(json.count).to eq 1
-        portfolio_item_ids = portfolio_items.map(&:id).sort
+        portfolio_item_ids = portfolio_items.map { |x| x.id.to_s }.sort
         expect(json.map { |x| x['id'] }.sort).to eq portfolio_item_ids
       end
     end
@@ -65,7 +65,7 @@ describe 'Portfolios API' do
       it 'returns all associated portfolio_items' do
         expect(json).not_to be_empty
         expect(json['data'].count).to eq 1
-        portfolio_item_ids = portfolio_items.map(&:id).sort
+        portfolio_item_ids = portfolio_items.map { |x| x.id.to_s }.sort
         expect(json['data'].map { |x| x['id'] }.sort).to eq portfolio_item_ids
       end
     end
@@ -77,7 +77,7 @@ describe 'Portfolios API' do
 
       it 'returns an associated portfolio_item for a specific portfolio' do
         expect(json).not_to be_empty
-        expect(json['id']).to eq portfolio_item_id
+        expect(json['id']).to eq portfolio_item_id.to_s
       end
     end
 
@@ -88,7 +88,7 @@ describe 'Portfolios API' do
 
       it 'returns an associated portfolio_item for a specific portfolio' do
         expect(json).not_to be_empty
-        expect(json['id']).to eq portfolio_item_id
+        expect(json['id']).to eq portfolio_item_id.to_s
       end
     end
 
@@ -106,7 +106,7 @@ describe 'Portfolios API' do
 
       it 'returns the portfolio_item which now points back to the portfolio' do
         expect(json.size).to eq 1
-        expect(json.first['portfolio_id']).to eq portfolio.id
+        expect(json.first['portfolio_id']).to eq portfolio.id.to_s
       end
     end
 
@@ -124,7 +124,7 @@ describe 'Portfolios API' do
 
       it 'returns the portfolio_item which now points back to the portfolio' do
         expect(json.size).to eq 1
-        expect(json.first['portfolio_id']).to eq portfolio.id
+        expect(json.first['portfolio_id']).to eq portfolio.id.to_s
       end
     end
 

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -23,6 +23,7 @@ describe 'Portfolios API' do
         it 'returns portfolio requested' do
           expect(json).not_to be_empty
           expect(json['id']).to eq(portfolio_id.to_s)
+          expect(json['created_at']).to eq(portfolio.created_at.iso8601)
         end
       end
     end


### PR DESCRIPTION
Override OpenAPI's `as_json` serializer so we can modify value types.

`id` and `*_id` returned as strings
Time objects returned as iso8601.

Similar approach as https://github.com/ManageIQ/topological_inventory-api/pull/80

Still needs specs