### PR TITLE
Use the entrypoint script to set env vars and run_rails_server in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN source /opt/rh/rh-postgresql10/enable && \
 
 COPY . $WORKDIR
 COPY docker-assets/entrypoint /usr/bin
+COPY docker-assets/run_rails_server /usr/bin
 
 RUN chgrp -R 0 $WORKDIR && \
     chmod -R g=u $WORKDIR
@@ -36,3 +37,4 @@ RUN chgrp -R 0 $WORKDIR && \
 EXPOSE 3000
 
 ENTRYPOINT ["entrypoint"]
+ENTRYPOINT ["run_rails_server"]

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,30 +1,13 @@
 #!/bin/bash
 
-export RAILS_ENV=production
-
-echo "== Writing encryption key =="
-cat > $WORKDIR/v2_key << KEY
----
-:algorithm: aes-256-cbc
-:key: ${ENCRYPTION_KEY}
-KEY
-
-function check_svc_status() {
-  local SVC_NAME=$1 SVC_PORT=$2
-
-  [[ $# -lt 2 ]] && echo "Error something seems wrong, we need at least two parameters to check service status" && exit 1
-
-  echo "== Checking ${SVC_NAME}:$SVC_PORT status =="
-
-  while true; do
-    ncat ${SVC_NAME} ${SVC_PORT} < /dev/null && break
-    sleep 5
-  done
-  echo "${SVC_NAME}:${SVC_PORT} - accepting connections"
+function urlescape() {
+  PAYLOAD="$1" ruby -rcgi -e "puts CGI.escape(ENV['PAYLOAD'])"
 }
 
-# Wait for postgres to be ready
-check_svc_status $DATABASE_HOST $DATABASE_PORT
+safeuser=$(urlescape ${DATABASE_USER})
+safepass=$(urlescape ${DATABASE_PASSWORD})
 
-bundle exec rake db:migrate
-bundle exec rails server
+export RAILS_ENV=production
+export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/catalog_production?encoding=utf8&pool=5&wait_timeout=5"
+
+exec ${@}

--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "== Writing encryption key =="
+cat > $WORKDIR/v2_key << KEY
+---
+:algorithm: aes-256-cbc
+:key: ${ENCRYPTION_KEY}
+KEY
+
+function check_svc_status() {
+  local SVC_NAME=$1 SVC_PORT=$2
+
+  [[ $# -lt 2 ]] && echo "Error something seems wrong, we need at least two parameters to check service status" && exit 1
+
+  echo "== Checking ${SVC_NAME}:$SVC_PORT status =="
+
+  while true; do
+    ncat ${SVC_NAME} ${SVC_PORT} < /dev/null && break
+    sleep 5
+  done
+  echo "${SVC_NAME}:${SVC_PORT} - accepting connections"
+}
+
+# Wait for postgres to be ready
+check_svc_status $DATABASE_HOST $DATABASE_PORT
+
+bundle exec rake db:migrate
+bundle exec rails server


### PR DESCRIPTION
This allows us to share environment variables in a sane way between
the CMD and users who may get a separate console session into a
running container.

This also provides a place for us to put the definition of
DATABASE_URL as it won't live in the database secret in production