### PR TITLE
Replace `/r/insights/platform` with `/api` as path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You would need 2 terminals for this setup
 
       export APP_NAME=catalog
       
-      export PATH_PREFIX=/r/insights/platform
+      export PATH_PREFIX=/api
       
       bin/rails s -p 5000
       

--- a/config/spandx/linux.js
+++ b/config/spandx/linux.js
@@ -3,7 +3,7 @@
 // The Insights UI is running on CI dev cluster
 module.exports = {
     routes: {
-        '/r/insights/platform/catalog': { host: 'http://localhost:5000' },
+        '/api/catalog': { host: 'http://localhost:5000' },
         '/insights': { host:  'PORTAL_BACKEND_MARKER' }
     }
 };

--- a/config/spandx/mac.js
+++ b/config/spandx/mac.js
@@ -3,7 +3,7 @@
 // The Insights UI is running on CI dev cluster
 module.exports = {
     routes: {
-        '/r/insights/platform/catalog': { host: 'http://host.docker.internal:5000' },
+        '/api/catalog': { host: 'http://host.docker.internal:5000' },
         '/insights': { host: 'PORTAL_BACKEND_MARKER' }
     }
 };

--- a/public/catalog/v0.0.1/openapi.json
+++ b/public/catalog/v0.0.1/openapi.json
@@ -750,10 +750,10 @@
     },
     "servers": [
         {
-            "url": "https://localhost/r/insights/platform/catalog"
+            "url": "https://localhost/api/catalog"
         },
         {
-            "url": "http://localhost/r/insights/platform/catalog"
+            "url": "http://localhost/api/catalog"
         }
     ],
     "components": {

--- a/public/catalog/v0.1.0/openapi.json
+++ b/public/catalog/v0.1.0/openapi.json
@@ -795,10 +795,10 @@
   },
   "servers": [
     {
-      "url": "https://localhost/r/insights/platform/catalog"
+      "url": "https://localhost/api/catalog"
     },
     {
-      "url": "http://localhost/r/insights/platform/catalog"
+      "url": "http://localhost/api/catalog"
     }
   ],
   "components": {


### PR DESCRIPTION
Updated to use new path_prefix value of `/api`