### PR TITLE
Update in-model as_json methods to use updated OpenApi method.

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -17,15 +17,11 @@ class Order < ApplicationRecord
   has_many :order_items
 
   after_initialize :set_defaults, unless: :persisted?
-  NON_DATE_ATTRIBUTES = %w(state)
-  DATE_ATTRIBUTES     = %w(created_at ordered_at completed_at)
+
+  AS_JSON_ATTRIBUTES = %w(id state created_at ordered_at completed_at).freeze
 
   def as_json(_options = {})
-    attributes.slice(*NON_DATE_ATTRIBUTES).tap do |hash|
-      DATE_ATTRIBUTES.each do |attr|
-        hash[attr] = self.send(attr.to_sym).iso8601 if self.send(attr.to_sym)
-      end
-    end.merge(:id => id.to_s)
+    super.slice(*AS_JSON_ATTRIBUTES)
   end
 
   def set_defaults

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -26,15 +26,11 @@ class OrderItem < ApplicationRecord
   has_many :progress_messages
   after_initialize :set_defaults, unless: :persisted?
 
-  NON_DATE_ATTRIBUTES = %w(order_id service_plan_ref portfolio_item_id state service_parameters provider_control_parameters external_ref)
-  DATE_ATTRIBUTES     = %w(created_at ordered_at completed_at updated_at)
+  AS_JSON_ATTRIBUTES = %w(id order_id service_plan_ref portfolio_item_id state service_parameters
+                          provider_control_parameters external_ref created_at ordered_at completed_at updated_at).freeze
 
   def as_json(_options = {})
-    attributes.slice(*NON_DATE_ATTRIBUTES).tap do |hash|
-      DATE_ATTRIBUTES.each do |attr|
-        hash[attr] = self.send(attr.to_sym).iso8601 if self.send(attr.to_sym)
-      end
-    end.merge(:id => id.to_s)
+    super.slice(*AS_JSON_ATTRIBUTES)
   end
 
   def set_defaults

--- a/app/models/progress_message.rb
+++ b/app/models/progress_message.rb
@@ -14,15 +14,11 @@ class ProgressMessage < ApplicationRecord
   acts_as_tenant(:tenant)
 
   after_initialize :set_defaults, unless: :persisted?
-  NON_DATE_ATTRIBUTES = %w(level message)
-  DATE_ATTRIBUTES     = %w(received_at)
+
+  AS_JSON_ATTRIBUTES = %w(id level message received_at).freeze
 
   def as_json(_options = {})
-    attributes.slice(*NON_DATE_ATTRIBUTES).tap do |hash|
-      DATE_ATTRIBUTES.each do |attr|
-        hash[attr] = self.send(attr.to_sym).iso8601 if self.send(attr.to_sym)
-      end
-    end.merge(:id => id.to_s)
+    super.slice(*AS_JSON_ATTRIBUTES)
   end
 
   def set_defaults


### PR DESCRIPTION
Removing in favor of the `as_json` changes in https://github.com/ManageIQ/catalog-api/pull/152