### PR TITLE
Replace before block with around for disabling tenancy

### DIFF
--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -3,22 +3,15 @@ RSpec.describe ApplicationController, :type => :request do
   let(:tenant)            { Tenant.create(:external_tenant => external_tenant) }
   let(:portfolio)         { Portfolio.create!(:name => 'tenant_portfolio', :description => 'tenant desc', :tenant_id => tenant.id, :owner => 'wilma') }
   let(:portfolio_id)      { portfolio.id }
-  let!(:external_tenant)  { "0369233" }
+  let(:external_tenant)   { "0369233" }
   let(:other_user)        { default_user_hash }
-
-  let(:identity) do
-    other_user['identity']['account_number'] = external_tenant
-    encoded_user_hash(other_user)
-  end
 
   context "with api version v0" do
     let(:api_version)       { api(0) }
     let(:api_minor_version) { api(0.1) }
 
     it "get api/v0/portfolios with tenant" do
-      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
-
-      get("#{api_version}/portfolios/#{portfolio_id}", :headers => headers)
+      get("#{api_version}/portfolios/#{portfolio_id}", :headers => default_headers)
       expect(response.status).to eq(301)
       expect(response.headers["Location"]).to eq "#{api_minor_version}/portfolios/#{portfolio_id}"
     end
@@ -35,9 +28,7 @@ RSpec.describe ApplicationController, :type => :request do
   context "with tenancy enforcement" do
 
     it "get /portfolios with tenant" do
-      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
-
-      get("/api/v0.0/portfolios/#{portfolio_id}", :headers => headers)
+      get("/api/v0.0/portfolios/#{portfolio_id}", :headers => admin_headers)
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to include("id" => portfolio_id.to_s)
@@ -53,8 +44,7 @@ RSpec.describe ApplicationController, :type => :request do
 
     it "get /portfolios with tenant" do
       portfolio
-      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
-      get("/api/v0.0/portfolios", :headers => headers)
+      get("/api/v0.0/portfolios", :headers => default_headers)
       expect(response.status).to eq(200)
     end
 
@@ -68,7 +58,11 @@ RSpec.describe ApplicationController, :type => :request do
   end
 
   context "without tenancy enforcement" do
-    before { disable_tenancy }
+    around do |example|
+      bypass_tenancy do
+        example.call
+      end
+    end
 
     it "get /portfolios" do
       headers = { "CONTENT_TYPE" => "application/json" }

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -3,10 +3,16 @@ describe Tenant do
     it "is enabled by default" do
       expect(Tenant.tenancy_enabled?).to be_truthy
     end
+  end
+
+  context "disable tenancy" do
+    around do |example|
+      bypass_tenancy do
+        example.call
+      end
+    end
 
     it "is disabled when ENV['BYPASS_TENANCY'] is set" do
-      disable_tenancy
-
       expect(ENV['BYPASS_TENANCY']).to be_truthy
       expect(Tenant.tenancy_enabled?).to be_falsey
     end

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -1,5 +1,9 @@
 describe "OrderItemsRequests", :type => :request do
-  before { disable_tenancy }
+  around do |example|
+    bypass_tenancy do
+      example.call
+    end
+  end
 
   let(:order) { create(:order) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,5 +1,9 @@
 describe "OrderRequests", :type => :request do
-  before { disable_tenancy }
+  around do |example|
+    bypass_tenancy do
+      example.call
+    end
+  end
 
   let!(:order) { create(:order) }
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -1,5 +1,9 @@
 describe "PortfolioItemRequests", :type => :request do
-  before { disable_tenancy }
+  around do |example|
+    bypass_tenancy do
+      example.call
+    end
+  end
 
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -1,5 +1,9 @@
 describe 'Portfolios API' do
-  before { disable_tenancy }
+  around do |example|
+    bypass_tenancy do
+      example.call
+    end
+  end
 
   let!(:portfolio)            { create(:portfolio) }
   let!(:portfolio_item)       { create(:portfolio_item) }

--- a/spec/requests/progress_message_spec.rb
+++ b/spec/requests/progress_message_spec.rb
@@ -1,5 +1,9 @@
 describe "ProgressMessageRequests", :type => :request do
-  before { disable_tenancy }
+  around do |example|
+    bypass_tenancy do
+      example.call
+    end
+  end
 
   let(:order) { create(:order) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }

--- a/spec/support/requests_spec_helper.rb
+++ b/spec/support/requests_spec_helper.rb
@@ -8,7 +8,7 @@ module RequestSpecHelper
     "/api/v#{version}"
   end
 
-  def disable_tenancy
-    stub_const("ENV", "BYPASS_TENANCY" => "true")
+  def bypass_tenancy
+    with_modified_env(:BYPASS_TENANCY => 'true') { yield }
   end
 end


### PR DESCRIPTION
Cleaning up the balance of the `before { disable_tenancy }` blocks with `around do |example|` blocks to clean up Thread Local Storage when enabling or disabling Tenant from the specs.