### PR TITLE
Add Hierarchical Model Lookup Service

### DIFF
--- a/app/services/catalog/hierarchical_model_search.rb
+++ b/app/services/catalog/hierarchical_model_search.rb
@@ -1,0 +1,50 @@
+module Catalog
+  class HierarchicalModelSearch
+    attr_reader :field
+    attr_reader :search_attribute
+    attr_reader :key
+    attr_reader :models
+
+    def initialize(search_attribute, key, models)
+      # The attribute/column to search for
+      @search_attribute = search_attribute
+      # The first primary key of the first element in the model list
+      @key = key
+      # map the models array (which is an array of strings) to their class counterparts
+      @models = models
+    end
+
+    def process
+      @models.each_with_index do |model, i|
+        break if @field.present?
+        @field = search_model(model.constantize, i)
+      end
+
+      self
+    end
+
+    private
+
+    def search_model(model, index)
+      record = model.find_by(:id => @key)
+
+      if record.respond_to?(@search_attribute) && record.send(@search_attribute).present?
+        record.send(@search_attribute)
+      else
+        get_next_model_key(record, index)
+        nil
+      end
+    end
+
+    def get_next_model_key(record, index)
+      # since we didn't find that field on the model, onto the next one.
+      # this code assumes the child class has `belongs_to` the parent,
+      # so the method to get its parent is present.
+      next_model = @models[index + 1].downcase
+      @key = record.send(next_model + "_id")
+    rescue NoMethodError
+      Rails.logger.error("Bad Hierarchy: [ #{@models.join(",")} ] for search key: #{@search_attribute}")
+      raise "Error fetching #{@search_attribute} from hierarchy #{@models.join(",")}"
+    end
+  end
+end

--- a/spec/services/catalog/hierarchical_model_search_spec.rb
+++ b/spec/services/catalog/hierarchical_model_search_spec.rb
@@ -1,0 +1,47 @@
+describe Catalog::HierarchicalModelSearch do
+  let!(:portfolio) { create(:portfolio) }
+  let!(:portfolio_item) { create(:portfolio_item) }
+  let(:portfolio_item_id) { portfolio_item.id }
+
+  let(:hierarchy) { %w[PortfolioItem Portfolio] }
+  let(:search_for) { "workflow_ref" }
+
+  let(:hierarchy_search) { described_class.new(search_for, portfolio_item_id, hierarchy) }
+
+  before do
+    portfolio.portfolio_items << portfolio_item
+  end
+
+  context "when the first item has the field to search for" do
+    let(:ref_text) { "first_item_workflow_ref" }
+
+    before do
+      portfolio_item.update(:workflow_ref => ref_text)
+    end
+
+    it "finds the field on the first item" do
+      expect(hierarchy_search.process.field).to eq ref_text
+    end
+  end
+
+  context "when the first item is missing the field" do
+    let(:ref_text) { "second_item_workflow_ref" }
+
+    before do
+      portfolio.update(:workflow_ref => ref_text)
+    end
+
+    it "fails to find the text on the first item, so it looks at the second one." do
+      expect(hierarchy_search.process.field).to eq ref_text
+    end
+  end
+
+  context "when the hierarchy passed in is missing a key reference to the next object" do
+    let(:bad_hierarchy) { %w[Portfolio PortfolioItem] }
+
+    it "throws an exception when trying to access the _id field" do
+      hierarchy_inst = described_class.new(search_for, portfolio_item_id, bad_hierarchy)
+      expect { hierarchy_inst.process }.to raise_exception(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
The service takes in the field one is looking for (and is common across the classes, workflow_ref is a good example), the first primary key (the key of the first model in the list), and finally a list of models.
It then iterates over the models and sees if the field exists going up the tree.