### PR TITLE
Create approval_requests table for OrderItem Approval process

### DIFF
--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -1,0 +1,6 @@
+class ApprovalRequest < ApplicationRecord
+  validates :workflow_ref, :presence => true
+  enum :state => [:undecided, :approved, :denied]
+
+  belongs_to :order_item
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -24,6 +24,7 @@ class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :portfolio_item
   has_many :progress_messages
+  has_many :approval_requests, :dependent => :destroy
   after_initialize :set_defaults, unless: :persisted?
 
   NON_DATE_ATTRIBUTES = %w(order_id service_plan_ref portfolio_item_id state service_parameters provider_control_parameters external_ref)

--- a/db/migrate/20190320170708_create_approval_requests.rb
+++ b/db/migrate/20190320170708_create_approval_requests.rb
@@ -1,0 +1,12 @@
+class CreateApprovalRequests < ActiveRecord::Migration[5.2]
+  def change
+    create_table :approval_requests do |t|
+      t.string :approval_request_ref
+      t.string :workflow_ref
+      t.string :state, :default => "undecided"
+      t.integer :order_item_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_12_200721) do
+ActiveRecord::Schema.define(version: 2019_03_20_170708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "approval_requests", force: :cascade do |t|
+    t.string "approval_request_ref"
+    t.string "workflow_ref"
+    t.string "state", default: "undecided"
+    t.integer "order_item_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "order_items", force: :cascade do |t|
     t.integer "count"

--- a/spec/factories/approval_requests.rb
+++ b/spec/factories/approval_requests.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :approval_request do
+    approval_request_ref { "MyString" }
+    workflow_ref { "MyString" }
+    state { :undecided }
+    order_item_id { "" }
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-233
This PR adds the AR models and tables for the new ApprovalRequest class.

The class will be used to track approvals on order_items, it has these fields:
```
approval_request_ref    # the id of the approval workflow
workflow_ref            # the workflow we requested
status                  # the status of the approval
order_item_id           # the order item this approval request belongs to
```