### PR TITLE
Switched to ManageIQ hosted gem for topology

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,6 @@ gem 'swagger_ui_engine'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
-gem 'topological_inventory-api-client', :git => "https://github.com/mkanoor/topological_inventory-api-client", :branch => "master"
+gem 'topological_inventory-api-client', :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 
 gem 'rbac-api-client', :git => "https://github.com/mkanoor/rbac_api_client", :branch => "master"


### PR DESCRIPTION
Use the topology client hosted at https://github.com/ManageIQ/topological_inventory-api-client-ruby