### PR TITLE
Create Approval Requests when Submitting an Order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
 gem 'topological_inventory-api-client', :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 
-gem 'approval_api_client', :git => 'https://github.com/hsong-rh/approval_api_ruby_client.git', :branch => "master"
+gem 'approval-api-client-ruby', :git => 'https://github.com/ManageIQ/approval-api-client-ruby', :branch => "master"
 gem 'rbac-api-client', :git => "https://github.com/RedHatInsights/insights-rbac-api-client-ruby", :branch => "master"

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
 gem 'topological_inventory-api-client', :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 
+gem 'approval_api_client', :git => 'https://github.com/hsong-rh/approval_api_ruby_client.git', :branch => "master"
 gem 'rbac-api-client', :git => "https://github.com/RedHatInsights/insights-rbac-api-client-ruby", :branch => "master"

--- a/app/controllers/api/v0x1/orders_controller.rb
+++ b/app/controllers/api/v0x1/orders_controller.rb
@@ -12,8 +12,10 @@ module Api
       end
 
       def submit_order
-        so = Catalog::SubmitOrder.new(params.require(:order_id))
-        render :json => so.process.order
+        approval = Catalog::CreateApprovalRequest.new(params.require(:order_id))
+        render :json => approval.process.order
+        # so = Catalog::SubmitOrder.new(params.require(:order_id))
+        # render :json => so.process.order
       end
     end
   end

--- a/app/controllers/api/v0x1/orders_controller.rb
+++ b/app/controllers/api/v0x1/orders_controller.rb
@@ -14,8 +14,6 @@ module Api
       def submit_order
         approval = Catalog::CreateApprovalRequest.new(params.require(:order_id))
         render :json => approval.process.order
-        # so = Catalog::SubmitOrder.new(params.require(:order_id))
-        # render :json => so.process.order
       end
     end
   end

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -1,0 +1,65 @@
+require 'approval_api_client'
+
+module Catalog
+  class CreateApprovalRequest
+    attr_reader :order
+
+    def initialize(id)
+      @order = Order.find_by!(:id => id)
+    end
+
+    def process
+      @order.order_items.each do |order_item|
+        approvals = send_approval_requests(order_item)
+        approvals.compact.each do |req|
+          order_item.approval_requests << create_approval_request(req)
+        end
+      end
+
+      @order.update(:status => "Ordered", :ordered_at => Time.now.utc)
+      self
+    rescue Catalog::AprovalError => e
+      Rails.logger.error("Error putting in approval Request for #{order.id}: #{e.message}")
+      raise
+    end
+
+    private
+
+    def send_approval_requests(order_item)
+      workflows(order_item.portfolio_item).map do |workflow|
+        Approval.call do |api_instance|
+          api_instance.create_request(workflow, request_body_from(order_item))
+        end
+      end
+    end
+
+    def request_body_from(order_item)
+      o_params = ActionController::Parameters.new('order_item_id' => order_item.id)
+      svc_params_sanitized = Catalog::OrderItemSanitizedParameters.new(o_params).process
+
+      ApprovalApiClient::RequestIn.new.tap do |request|
+        request.requester = ManageIQ::API::Common::Request.current.user.username
+        request.name      = order_item.portfolio_item.name
+        request.content   = {
+          :product   => order_item.portfolio_item.name,
+          :portfolio => order_item.portfolio_item.portfolio.name,
+          :order_id  => order_item.order_id,
+          :params    => svc_params_sanitized.to_json
+        }
+      end
+    end
+
+    def workflows(portfolio_item)
+      portfolio_item.resolved_workflow_refs
+    end
+
+    def create_approval_request(req)
+      ApprovalRequest.new.tap do |approval|
+        approval.workflow_ref         = req.workflow_id
+        approval.approval_request_ref = req.id
+        approval.status               = req.decision
+        approval.save
+      end
+    end
+  end
+end

--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -1,0 +1,48 @@
+module Catalog
+  class OrderItemSanitizedParameters < TopologyServiceApi
+    MASKED_VALUE = "********".freeze
+
+    def process
+      sanitized_parameters
+    rescue StandardError => e
+      Rails.logger.error("OrderItemSanitizedParameters #{e.message}")
+      raise
+    end
+
+    private
+
+    def order_item
+      @order_item ||= OrderItem.find(params[:order_item_id])
+    end
+
+    def service_plan_ref
+      order_item.service_plan_ref
+    end
+
+    def service_parameters
+      order_item.service_parameters
+    end
+
+    def service_plan_schema
+      plan = api_instance.show_service_plan(service_plan_ref)
+      plan.create_json_schema
+    rescue TopologicalInventoryApiClient::ApiError => e
+      Rails.logger.error("DefaultApi->show_service_plan #{e.message}")
+      raise
+    end
+
+    def sanitized_parameters
+      svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
+      service_plan_schema[:properties].each_with_object({}) do |(key, attrs), result|
+        value = hide?(key, attrs) ? MASKED_VALUE : svc_params[key]
+        result[attrs[:title]] = value
+      end
+    end
+
+    def hide?(key, attrs)
+      attrs[:format] == "password" ||
+        /password/i.match?(attrs[:title]) ||
+        /password/i.match?(key)
+    end
+  end
+end

--- a/lib/approval.rb
+++ b/lib/approval.rb
@@ -1,4 +1,4 @@
-require 'approval_api_client'
+require 'approval-api-client-ruby'
 
 class Approval
   def self.approval_api
@@ -8,7 +8,7 @@ class Approval
   def self.call
     pass_thru_headers
     yield approval_api
-  rescue ApprovalAPIClient::APIError => e
+  rescue ApprovalApiClient::ApiError => e
     Rails.logger.error("ApprovalApiClient::ApiError #{e.message}")
     raise Catalog::ApprovalError, e.message
   end
@@ -24,6 +24,6 @@ class Approval
 
   private_class_method def self.pass_thru_headers
     headers = ManageIQ::API::Common::Request.current_forwardable
-    approval_api.api_client.default_headers = api.api_client.default_headers.merge(headers)
+    approval_api.api_client.default_headers.merge!(headers)
   end
 end

--- a/lib/approval.rb
+++ b/lib/approval.rb
@@ -1,0 +1,29 @@
+require 'approval_api_client'
+
+class Approval
+  def self.approval_api
+    Thread.current[:approval_api_instance] ||= raw_api
+  end
+
+  def self.call
+    pass_thru_headers
+    yield approval_api
+  rescue ApprovalAPIClient::APIError => e
+    Rails.logger.error("ApprovalApiClient::ApiError #{e.message}")
+    raise Catalog::ApprovalError, e.message
+  end
+
+  private_class_method def self.raw_api
+    ApprovalApiClient.configure do |config|
+      config.host = ENV['APPROVAL_URL'] || 'localhost'
+      config.scheme = URI.parse(ENV['APPROVAL_URL']).try(:scheme) || 'http'
+      dev_credentials(config)
+    end
+    ApprovalApiClient::RequestApi.new
+  end
+
+  private_class_method def self.pass_thru_headers
+    headers = ManageIQ::API::Common::Request.current_forwardable
+    approval_api.api_client.default_headers = api.api_client.default_headers.merge(headers)
+  end
+end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -2,4 +2,5 @@ module Catalog
   class TopologyError < StandardError; end
   class RBACError < StandardError; end
   class NoTenantError < StandardError; end
+  class ApprovalError < StandardError; end
 end

--- a/spec/lib/approval_spec.rb
+++ b/spec/lib/approval_spec.rb
@@ -1,0 +1,14 @@
+describe Approval do
+  let(:topo_ex) { ApprovalApiClient::ApiError.new("kaboom") }
+
+  it "raises ApprovalError" do
+    with_modified_env :APPROVAL_URL => 'http://www.example.com' do
+      allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
+      expect do
+        described_class.call do |_api|
+          raise topo_ex
+        end
+      end.to raise_exception(Catalog::ApprovalError)
+    end
+  end
+end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -7,15 +7,17 @@ describe "OrderRequests", :type => :request do
 
   let!(:order) { create(:order) }
 
+  # TODO: Update this context with new logic. Will be fixed with
+  # https://projects.engineering.redhat.com/browse/SSP-237
   context "submit order" do
-    let(:svc_object) { instance_double("Catalog::SubmitOrder") }
+    let(:svc_object) { instance_double("Catalog::CreateApprovalRequest") }
     let(:topo_ex) { Catalog::TopologyError.new("kaboom") }
     let(:params) { order.id.to_s }
     before do
-      allow(Catalog::SubmitOrder).to receive(:new).with(params).and_return(svc_object)
+      allow(Catalog::CreateApprovalRequest).to receive(:new).with(params).and_return(svc_object)
     end
 
-    it "successfully adds submits an order" do
+    it "successfully creates approval requests" do
       allow(svc_object).to receive(:process).and_return(svc_object)
       allow(svc_object).to receive(:order).and_return(order)
 
@@ -25,14 +27,7 @@ describe "OrderRequests", :type => :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "raises error" do
-      allow(svc_object).to receive(:process).and_raise(topo_ex)
-
-      post "/api/v0.0/orders/#{order.id}", :headers => admin_headers
-      expect(response).to have_http_status(:internal_server_error)
-    end
-
-    it "v0.1 successfully adds submits an order" do
+    it "v0.1 successfully creates approval requests" do
       allow(svc_object).to receive(:process).and_return(svc_object)
       allow(svc_object).to receive(:order).and_return(order)
 
@@ -40,13 +35,6 @@ describe "OrderRequests", :type => :request do
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
-    end
-
-    it "v0.1 raises error" do
-      allow(svc_object).to receive(:process).and_raise(topo_ex)
-
-      post "#{api('0.1')}/orders/#{order.id}/submit_order", :headers => admin_headers
-      expect(response).to have_http_status(:internal_server_error)
     end
   end
 

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -1,0 +1,104 @@
+describe Catalog::CreateApprovalRequest do
+  let(:create_approval_request) { described_class.new(order.id) }
+
+  let(:workflow_ref) { "1" }
+  let!(:order) { create(:order) }
+  let!(:portfolio) { create(:portfolio) }
+  let!(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :workflow_ref => workflow_ref) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+
+  let(:approval) { class_double(Approval).as_stubbed_const(:transfer_nested_constants => true) }
+  let(:api_instance) { instance_double(ApprovalApiClient::RequestApi) }
+  let(:approval_response) { ApprovalApiClient::RequestOut.new(:id => 1, :decision => "undecided", :workflow_id => workflow_ref) }
+
+  let(:sanitize_service_class) do
+    class_double(Catalog::OrderItemSanitizedParameters).as_stubbed_const(:transfer_nested_constants => true)
+  end
+  let(:sanitize_service_instance) { instance_double(Catalog::OrderItemSanitizedParameters) }
+  let(:hashy) { { :a => 1 } }
+  let(:approval_error) { Catalog::ApprovalError.new("kaboom") }
+
+  before do
+    allow(sanitize_service_class).to receive(:new).and_return(sanitize_service_instance)
+    allow(sanitize_service_instance).to receive(:process).and_return(hashy)
+  end
+
+  describe "#process" do
+    let(:request) { create_approval_request.process }
+
+    context "when the approval succeeds" do
+      before do
+        allow(approval).to receive(:call).and_yield(api_instance)
+        allow(api_instance).to receive(:create_request).and_return(approval_response)
+      end
+
+      it "submits the approval request" do
+        expect(request.order.state).to eq "Ordered"
+      end
+
+      it "sets up the approval_request on the order item" do
+        item = request.order.order_items.first
+        expect(item.approval_requests.count).to eq 1
+      end
+    end
+
+    context "when the approval fails" do
+      before do
+        allow(approval).to receive(:call).and_raise(approval_error)
+      end
+
+      it "raises an error" do
+        expect { request }.to raise_exception(Catalog::ApprovalError)
+      end
+    end
+  end
+
+  context "private methods" do
+    before do
+      allow(approval).to receive(:call).and_yield(api_instance)
+      allow(api_instance).to receive(:create_request).and_return(approval_response)
+    end
+
+    context "#submit_approval_requests" do
+      it "calls out to Approval for every workflow on the order" do
+        expect(approval).to receive(:call).once
+        create_approval_request.send(:submit_approval_requests, order_item)
+      end
+    end
+
+    context "#create_approval_request" do
+      let(:request_out) { ApprovalApiClient::RequestOut.new(:workflow_id => "1", :id => 2) }
+      let(:approval_request) { create_approval_request.send(:create_approval_request, request_out) }
+
+      it "returns an ApprovalRequest Object" do
+        expect(approval_request.class.name).to eq "ApprovalRequest"
+      end
+
+      it "populates all of the fields from the Response from Approval" do
+        resp = approval_request
+        expect(resp.workflow_ref).to eql request_out.workflow_id
+        expect(resp.approval_request_ref).to eq request_out.id.to_s
+        expect(resp.state).to eq request_out.decision
+      end
+    end
+
+    context "#workflows" do
+      it "returns the workflow from portfolio_item" do
+        workflows = create_approval_request.send(:workflows, portfolio_item)
+        expect(workflows.first).to eq portfolio_item.workflow_ref
+      end
+    end
+
+    context "#request_body_from" do
+      it "returns a RequestIn Object populated with all of the order_item information" do
+        req = create_approval_request.send(:request_body_from, order_item)
+
+        expect(req.name).to eq order_item.portfolio_item.name
+        expect(req.content).to include(:product   => order_item.portfolio_item.name,
+                                       :portfolio => order_item.portfolio_item.portfolio.name,
+                                       :order_id  => order_item.order_id,
+                                       :params    => hashy.to_json)
+      end
+    end
+  end
+end

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -1,0 +1,74 @@
+describe Catalog::OrderItemSanitizedParameters do
+  include ServiceSpecHelper
+
+  Plan = Struct.new(:name, :id, :description, :create_json_schema)
+  let(:plan) { Plan.new("Plan A", "1", "Plan A", json_schema) }
+  let(:api_instance) { double(:api_instance) }
+  let(:service_plan_ref) { "777" }
+  let(:oisp) do
+    with_modified_env :TOPOLOGY_SERVICE_URL => 'http://www.example.com' do
+      Catalog::OrderItemSanitizedParameters.new(params)
+    end
+  end
+
+  let(:order_item) do
+    create(:order_item, :portfolio_item_id           => 100,
+                        :order_id                    => 45,
+                        :service_plan_ref            => service_plan_ref,
+                        :service_parameters          => service_parameters,
+                        :provider_control_parameters => { 'a' => 1 },
+                        :count                       => 1)
+  end
+
+  let(:json_schema) { { :properties => properties } }
+
+  let(:properties) do
+    {'user'     => {:title => 'User Name', :type => 'string'},
+     'password' => {:title => 'Secret', :type => 'string'},
+     'newpwd'   => {:title => 'Users Password', :type => 'string'},
+     'salary'   => {:title => 'Salary', :format => 'password', :type => 'number'},
+     'db_name'  => {:title => 'Database Name', :type => 'string'}}
+  end
+
+  let(:service_parameters) do
+    { 'user'     => 'Fred Flintstone',
+      'password' => 'Yabba Dabba Doo',
+      'salary'   => 10_000_000,
+      'newpwd'   => 'Yabba Dabba Two',
+      'db_name'  => 'Slate Rocking Company' }
+  end
+
+  let(:params) do
+    ActionController::Parameters.new('order_item_id' => order_item.id)
+  end
+
+  let(:topological_inventory) do
+    class_double(TopologicalInventory).as_stubbed_const(:transfer_nested_constants => true)
+  end
+
+  before do
+    allow(topological_inventory).to receive(:call).and_yield(api_instance)
+    allow(api_instance).to receive(:show_service_plan).and_return(plan)
+    allow(plan).to receive(:create_json_schema).and_return(json_schema)
+  end
+
+  context "#process" do
+    it "success scenario" do
+      expect(api_instance).to receive(:show_service_plan)
+        .with(order_item.service_plan_ref)
+        .and_return(plan)
+
+      result = oisp.process
+
+      expect(result.values.select { |v| v == described_class::MASKED_VALUE }.count).to eq(3)
+    end
+
+    it "failure scenario" do
+      expect(api_instance).to receive(:show_service_plan)
+        .with(order_item.service_plan_ref)
+        .and_raise(TopologicalInventoryApiClient::ApiError.new("Kaboom"))
+
+      expect { oisp.process }.to raise_error(StandardError)
+    end
+  end
+end

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -11,9 +11,9 @@ describe Catalog::ServicePlans do
   end
 
   it "fetches the array of plans" do
-    Plan = Struct.new(:name, :id, :description, :create_json_schema)
-    plan1 = Plan.new("Plan A", "1", "Plan A", {})
-    plan2 = Plan.new("Plan B", "2", "Plan B", {})
+    SvcPlan = Struct.new(:name, :id, :description, :create_json_schema)
+    plan1 = SvcPlan.new("Plan A", "1", "Plan A", {})
+    plan2 = SvcPlan.new("Plan B", "2", "Plan B", {})
     result = double('links' => {}, 'meta' => {}, 'data' => [plan1, plan2])
     expect(api_instance).to receive(:list_service_offering_service_plans).with(portfolio_item.service_offering_ref).and_return(result)
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-235

This PR adds integration with the Approval API when submitting an order. When `submit_order` is called the service goes through all of the workflows on all of the items in the order and submits them, storing the progress in the `ApprovalRequests` table. 
