### PR TITLE
Sync order_item and progress message update times

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -40,10 +40,8 @@ class OrderItem < ApplicationRecord
   end
 
   def update_message(level, message)
-    self.updated_at = Time.zone.now
-    ProgressMessage.create(:level         => level,
-                           :message       => message,
-                           :order_item_id => id)
+    progress_messages << ProgressMessage.new(:level => level, :message => message)
+    touch
   end
 
   def monitor

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,16 @@
+describe OrderItem do
+  let(:order) { create(:order) }
+  let(:order_item) do
+    create(:order_item, :order_id => order.id, :portfolio_item_id => 123)
+  end
+
+  context "updating order item progress messages" do
+    it "syncs the time between order_item and progress message" do
+      order_item.update_message("test_level", "test message")
+      order_item.reload
+      last_message = order_item.progress_messages.last
+      expect(order_item.updated_at).to be_a(Time)
+      expect(last_message.order_item_id.to_i).to eq order_item.id
+    end
+  end
+end


### PR DESCRIPTION
Allow the `ProgressMessage` records to sync the updated_at timestamps for the parent `OrderItem`.