### PR TITLE
Added route to fetch openapi.json

### DIFF
--- a/app/controllers/api/v1x0.rb
+++ b/app/controllers/api/v1x0.rb
@@ -1,4 +1,9 @@
 module Api
   module V1x0
+    class RootController < ApplicationController
+      def openapi
+        render :json => Rails.root.join('public', 'catalog', 'v0.1.0', 'openapi.json').read
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   scope :as => :api, :module => "api", :path => prefix do
     match "/v1/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v1.0/%{path}", :only_path => true)
     namespace :v1x0, :path => "v1.0" do
+      get "/openapi.json", :to => "root#openapi"
       post '/orders/:order_id/submit_order', :action => 'submit_order', :controller => 'orders', :as => 'order_submit_order'
       resources :orders,                :only => [:create, :index] do
         resources :order_items,           :only => [:create, :index, :show]

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,0 +1,10 @@
+describe "root", :type => :request do
+  context "v1" do
+    it "#openapi.json" do
+      get("/api/v1.0/openapi.json", :headers => default_headers)
+
+      expect(response.content_type).to eq("application/json")
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Copies the behaviour from topology service
https://github.com/ManageIQ/topological_inventory-api/blob/e797774c516442e4e0957f0c14333c6fba51e3fe/app/controllers/api/v0x1.rb#L3
Requirement for IPP
