### PR TITLE
Removed the bypass tenancy block

### DIFF
--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -1,17 +1,12 @@
 describe "OrderItemsRequests", :type => :request do
-  around do |example|
-    bypass_tenancy do
-      example.call
-    end
-  end
-
-  let(:order) { create(:order) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let!(:order) { create(:order, :tenant_id => tenant.id) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
 
   context "v1" do
     it "lists order items" do
-      get "/api/v1.0/orders/#{order.id}/order_items"
+      get "/api/v1.0/orders/#{order.id}/order_items", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,11 +1,6 @@
 describe "OrderRequests", :type => :request do
-  around do |example|
-    bypass_tenancy do
-      example.call
-    end
-  end
-
-  let!(:order) { create(:order) }
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let!(:order) { create(:order, :tenant_id => tenant.id) }
 
   # TODO: Update this context with new logic. Will be fixed with
   # https://projects.engineering.redhat.com/browse/SSP-237
@@ -21,7 +16,7 @@ describe "OrderRequests", :type => :request do
       allow(svc_object).to receive(:process).and_return(svc_object)
       allow(svc_object).to receive(:order).and_return(order)
 
-      post "#{api}/orders/#{order.id}/submit_order", :headers => admin_headers
+      post "#{api}/orders/#{order.id}/submit_order", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
@@ -38,7 +33,7 @@ describe "OrderRequests", :type => :request do
       allow(svc_object).to receive(:process).and_return(svc_object)
       allow(svc_object).to receive(:order).and_return(order)
 
-      post "/api/v1.0/orders/#{order.id}/order_items", :headers => admin_headers
+      post "/api/v1.0/orders/#{order.id}/order_items", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
@@ -47,7 +42,7 @@ describe "OrderRequests", :type => :request do
 
   context "list orders" do
     it "lists orders v1.0" do
-      get "/api/v1.0/orders"
+      get "/api/v1.0/orders", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)

--- a/spec/requests/progress_message_spec.rb
+++ b/spec/requests/progress_message_spec.rb
@@ -1,18 +1,13 @@
 describe "ProgressMessageRequests", :type => :request do
-  around do |example|
-    bypass_tenancy do
-      example.call
-    end
-  end
-
-  let(:order) { create(:order) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
-  let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s) }
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+  let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
 
   context "v1.0" do
     it "lists progress messages" do
-      get "/#{api}/order_items/#{order_item.id}/progress_messages"
+      get "/#{api}/order_items/#{order_item.id}/progress_messages", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
This makes the code consistent with Approval and ManageIQ use of
tenancy, where the tenancy is set when the model is built and by
passing a default header we can have the tenancy be enforced.

This does only 3 specs there are 2 more specs to fixed.