### PR TITLE
Service Parameters from json -> hash when submitting approval request

### DIFF
--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -38,7 +38,7 @@ module Catalog
           :product   => order_item.portfolio_item.name,
           :portfolio => order_item.portfolio_item.portfolio.name,
           :order_id  => order_item.order_id,
-          :params    => svc_params_sanitized.to_json
+          :params    => svc_params_sanitized
         }
       end
     end

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -97,7 +97,7 @@ describe Catalog::CreateApprovalRequest do
         expect(req.content).to include(:product   => order_item.portfolio_item.name,
                                        :portfolio => order_item.portfolio_item.portfolio.name,
                                        :order_id  => order_item.order_id,
-                                       :params    => hashy.to_json)
+                                       :params    => hashy)
       end
     end
   end


### PR DESCRIPTION
This PR updates the logic when constructing the Approval Request, where I accidentally used the json representation of the data rather than just leaving it as a hash. It'll get tranformed to json later when making the request.