### PR TITLE
Expose Approval Requests via subresource on order_items

### DIFF
--- a/app/controllers/api/v1x0/approval_requests_controller.rb
+++ b/app/controllers/api/v1x0/approval_requests_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1x0
+    class ApprovalRequestsController < ApplicationController
+      include Api::V1x0::Mixins::IndexMixin
+
+      def index
+        collection(ApprovalRequest.where(:order_item_id => params.require(:order_item_id)))
+      end
+    end
+  end
+end

--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -1,4 +1,5 @@
 class ApprovalRequest < ApplicationRecord
+  acts_as_tenant(:tenant)
   validates :workflow_ref, :presence => true
   enum :state => [:undecided, :approved, :denied]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       end
       resources :order_items,           :only => [:index, :show] do
         resources :progress_messages,     :only => [:index]
+        resources :approval_requests,     :only => [:index]
       end
       post '/portfolios/:portfolio_id/portfolio_items', :action => 'add_portfolio_item_to_portfolio', :controller => 'portfolios', :as => 'add_portfolio_item_to_portfolio'
       post '/portfolios/:portfolio_id/share', :action => 'share', :controller => 'portfolios', :as => 'share'

--- a/db/migrate/20190402184014_add_tenant_to_approval_requests.rb
+++ b/db/migrate/20190402184014_add_tenant_to_approval_requests.rb
@@ -1,0 +1,6 @@
+class AddTenantToApprovalRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :approval_requests, :tenant_id, :bigint
+    add_index :approval_requests, :tenant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_22_202902) do
+ActiveRecord::Schema.define(version: 2019_04_02_184014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2019_03_22_202902) do
     t.datetime "updated_at", null: false
     t.string "reason"
     t.integer "state", default: 0
+    t.bigint "tenant_id"
+    t.index ["tenant_id"], name: "index_approval_requests_on_tenant_id"
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -936,6 +936,49 @@
           }
         }
       }
+    },
+    "/order_items/{order_item_id}/approval_requests": {
+      "get": {
+        "tags": [
+          "users",
+          "admins"
+        ],
+        "summary": "Gets a list of approval requests for an item",
+        "operationId": "listApprovalRequests",
+        "description": "Gets a list of approval request associated with an order item. As the item is being approved one can check the status of the approvals.\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderItemID"
+          },
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a ApprovalRequestCollection object with an embedded array of ProgressMessage objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalRequestsCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Order item not found"
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -1334,6 +1377,52 @@
           }
         }
       },
+      "ApprovalRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "ID",
+            "description": "The unique identifier for this approval request.",
+            "readOnly": true
+          },
+          "approval_request_ref": {
+            "type": "string",
+            "title": "Approval Request Ref",
+            "description": "The id of the approval submitted to approval-api",
+            "readOnly": true
+          },
+          "order_item_id": {
+            "type": "string",
+            "title": "Order Item ID",
+            "description": "The Order Item which the approval request belongs to",
+            "readOnly": true
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "description": "The reason for the current state.",
+            "readOnly": true
+          },
+          "state": {
+            "type": "string",
+            "title": "State",
+            "enum": [
+              "undecided",
+              "approved",
+              "denied"
+            ],
+            "description": "The state of the approval request (approved, denied, undecided)",
+            "readOnly": true
+          },
+          "workflow_ref": {
+            "type": "string",
+            "title": "Workflow Ref",
+            "description": "The workflow that was requested",
+            "readOnly": true
+          }
+        }
+      },
       "ProgressMessage": {
         "type": "object",
         "properties": {
@@ -1460,6 +1549,23 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/OrderItem"
+            }
+          }
+        }
+      },
+      "ApprovalRequestsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovalRequest"
             }
           }
         }

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -13,4 +13,23 @@ describe "OrderItemsRequests", :type => :request do
       expect(JSON.parse(response.body)['data'].first['id']).to eq(order_item.id.to_s)
     end
   end
+
+  describe "#approval_requests" do
+    let!(:approval) { create(:approval_request, :order_item_id => order_item.id, :workflow_ref => "1") }
+
+    context "list" do
+      before do
+        get "#{api}/order_items/#{order_item.id}/approval_requests", :headers => default_headers
+      end
+
+      it "returns a 200 http status" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "lists approval requests" do
+        expect(json["data"].count).to eq 1
+        expect(json["data"].first["id"]).to eq approval.id.to_s
+      end
+    end
+  end
 end

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -15,7 +15,7 @@ describe "OrderItemsRequests", :type => :request do
   end
 
   describe "#approval_requests" do
-    let!(:approval) { create(:approval_request, :order_item_id => order_item.id, :workflow_ref => "1") }
+    let!(:approval) { create(:approval_request, :order_item_id => order_item.id, :workflow_ref => "1", :tenant_id => tenant.id) }
 
     context "list" do
       before do

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -5,7 +5,7 @@ describe Catalog::CreateApprovalRequest do
   let!(:order) { create(:order) }
   let!(:portfolio) { create(:portfolio) }
   let!(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :workflow_ref => workflow_ref) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => 1) }
 
   let(:approval) { class_double(Approval).as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { instance_double(ApprovalApiClient::RequestApi) }


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-254

Adds `/order_items/{order_item_id}/approval_requests` so users can query the approvals that are present on an `OrderItem`. 