### PR TITLE
Set tenant in progress_message from order_item

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -40,7 +40,7 @@ class OrderItem < ApplicationRecord
   end
 
   def update_message(level, message)
-    progress_messages << ProgressMessage.new(:level => level, :message => message)
+    progress_messages << ProgressMessage.new(:level => level, :message => message, :tenant_id => self.tenant_id)
     touch
   end
 

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,8 +1,7 @@
 describe OrderItem do
-  let(:order) { create(:order) }
-  let(:order_item) do
-    create(:order_item, :order_id => order.id, :portfolio_item_id => 123)
-  end
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
+  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => 123, :tenant_id => tenant.id) }
 
   context "updating order item progress messages" do
     it "syncs the time between order_item and progress message" do
@@ -11,6 +10,7 @@ describe OrderItem do
       last_message = order_item.progress_messages.last
       expect(order_item.updated_at).to be_a(Time)
       expect(last_message.order_item_id.to_i).to eq order_item.id
+      expect(last_message.tenant_id).to eq(tenant.id)
     end
   end
 end


### PR DESCRIPTION
The progress messages were being created without a tenant_id.