### PR TITLE
Add 'Approval Pending' state to Order OpenAPI JSON

### DIFF
--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1294,6 +1294,7 @@
             "type": "string",
             "enum": [
               "Created",
+              "Approval Pending",
               "Ordered",
               "Failed",
               "Completed"


### PR DESCRIPTION
Forgot to add the new state to the OpenAPI json.