### PR TITLE
Move order update processing to separate class and fix progress messages

### DIFF
--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -11,8 +11,7 @@ module Catalog
       Rails.logger.info("Processing service order topic message: #{@message} with payload: #{@payload}")
 
       Rails.logger.info("Searching for OrderItem with a task_ref: #{@payload["task_id"]}")
-      order_item = OrderItem.where(:topology_task_ref => @payload["task_id"]).first
-      raise OrderItemNotFound if order_item.nil?
+      order_item = find_order_item
       Rails.logger.info("Found OrderItem: #{order_item.id}")
 
       order_item.update_message("info", "Task update message received with payload: #{@payload}")
@@ -25,6 +24,15 @@ module Catalog
         order_item.save!
         Rails.logger.info("Finished updating OrderItem: #{order_item.id} with 'Order Completed' state")
       end
+    end
+
+    private
+
+    def find_order_item
+      order_item = OrderItem.where(:topology_task_ref => @payload["task_id"]).first
+      raise OrderItemNotFound if order_item.nil?
+
+      order_item
     rescue OrderItemNotFound
       Rails.logger.error("Could not find an OrderItem with topology_task_ref: #{@payload["task_id"]}")
       raise "Could not find an OrderItem with topology_task_ref: #{@payload["task_id"]}"

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -14,15 +14,17 @@ module Catalog
       order_item = find_order_item
       Rails.logger.info("Found OrderItem: #{order_item.id}")
 
-      order_item.update_message("info", "Task update message received with payload: #{@payload}")
+      ManageIQ::API::Common::Request.with_request(order_item.context.transform_keys(&:to_sym)) do
+        order_item.update_message("info", "Task update message received with payload: #{@payload}")
 
-      if @payload["state"] == "completed"
-        order_item.state = "Order Completed"
-        order_item.update_message("info", "Order Complete")
+        if @payload["state"] == "completed"
+          order_item.state = "Order Completed"
+          order_item.update_message("info", "Order Complete")
 
-        Rails.logger.info("Updating OrderItem: #{order_item.id} with 'Order Completed' state")
-        order_item.save!
-        Rails.logger.info("Finished updating OrderItem: #{order_item.id} with 'Order Completed' state")
+          Rails.logger.info("Updating OrderItem: #{order_item.id} with 'Order Completed' state")
+          order_item.save!
+          Rails.logger.info("Finished updating OrderItem: #{order_item.id} with 'Order Completed' state")
+        end
       end
     end
 

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -1,0 +1,33 @@
+module Catalog
+  class UpdateOrderItem
+    class OrderItemNotFound < StandardError; end
+
+    def initialize(topic)
+      @payload = topic.payload
+      @message = topic.message
+    end
+
+    def process
+      Rails.logger.info("Processing service order topic message: #{@message} with payload: #{@payload}")
+
+      Rails.logger.info("Searching for OrderItem with a task_ref: #{@payload["task_id"]}")
+      order_item = OrderItem.where(:topology_task_ref => @payload["task_id"]).first
+      raise OrderItemNotFound if order_item.nil?
+      Rails.logger.info("Found OrderItem: #{order_item.id}")
+
+      order_item.update_message("info", "Task update message received with payload: #{@payload}")
+
+      if @payload["state"] == "completed"
+        order_item.state = "Order Completed"
+        order_item.update_message("info", "Order Complete")
+
+        Rails.logger.info("Updating OrderItem: #{order_item.id} with 'Order Completed' state")
+        order_item.save!
+        Rails.logger.info("Finished updating OrderItem: #{order_item.id} with 'Order Completed' state")
+      end
+    rescue OrderItemNotFound
+      Rails.logger.error("Could not find an OrderItem with topology_task_ref: #{@payload["task_id"]}")
+      raise "Could not find an OrderItem with topology_task_ref: #{@payload["task_id"]}"
+    end
+  end
+end

--- a/spec/lib/service_order_listener_spec.rb
+++ b/spec/lib/service_order_listener_spec.rb
@@ -10,21 +10,8 @@ describe ServiceOrderListener do
       ManageIQ::API::Common::Request.with_request(request) { example.call }
     end
 
-    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client) }
-    let(:payload) { {"task_id" => "123", "state" => state} }
-    let!(:item) do
-      OrderItem.create!(
-        :count                       => 1,
-        :service_parameters          => "test",
-        :provider_control_parameters => "test",
-        :order                       => order,
-        :service_plan_ref            => "321",
-        :portfolio_item              => portfolio_item,
-        :topology_task_ref           => topology_task_ref
-      )
-    end
-    let(:order) { Order.create! }
-    let(:portfolio_item) { PortfolioItem.create!(:service_offering_ref => "321") }
+    let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
+    let(:update_order_item) { double("Catalog::UpdateOrderItem") }
 
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).with(
@@ -38,77 +25,12 @@ describe ServiceOrderListener do
         :max_bytes   => 500_000
       ).and_yield(message)
       allow(client).to receive(:close)
+      allow(Catalog::UpdateOrderItem).to receive(:new).with(message).and_return(update_order_item)
     end
 
-    context "when the order item is not findable" do
-      let(:topology_task_ref) { "0" }
-
-      context "when the state of the task is anything else" do
-        let(:state) { "test" }
-
-        it "creates a progress message about the payload" do
-          subject.subscribe_to_task_updates
-          latest_progress_message = ProgressMessage.last
-          expect(latest_progress_message.level).to eq("info")
-          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-        end
-      end
-
-      context "when the state of the task is completed" do
-        let(:state) { "completed" }
-
-        it "creates a progress message about the payload" do
-          subject.subscribe_to_task_updates
-          latest_progress_message = ProgressMessage.second_to_last
-          expect(latest_progress_message.level).to eq("info")
-          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-        end
-
-        it "creates a progress message with an error" do
-          subject.subscribe_to_task_updates
-          latest_progress_message = ProgressMessage.last
-          expect(latest_progress_message.level).to eq("error")
-          expect(latest_progress_message.message).to eq("Could not find OrderItem with topology_task_ref of 123")
-        end
-      end
-    end
-
-    context "when the order item is findable" do
-      let(:topology_task_ref) { "123" }
-
-      context "when the state of the task is anything else" do
-        let(:state) { "test" }
-
-        it "creates a progress message about the payload" do
-          subject.subscribe_to_task_updates
-          latest_progress_message = ProgressMessage.last
-          expect(latest_progress_message.level).to eq("info")
-          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-        end
-
-        it "does not update the order" do
-          subject.subscribe_to_task_updates
-          item.reload
-          expect(item.state).to eq("Created")
-        end
-      end
-
-      context "when the state of the task is completed" do
-        let(:state) { "completed" }
-
-        it "creates a progress message about the payload" do
-          subject.subscribe_to_task_updates
-          latest_progress_message = ProgressMessage.second_to_last
-          expect(latest_progress_message.level).to eq("info")
-          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-        end
-
-        it "updates the order item to be completed" do
-          subject.subscribe_to_task_updates
-          item.reload
-          expect(item.state).to eq("Order Completed")
-        end
-      end
+    it "delegates all processing to the UpdateOrderItem serice" do
+      expect(update_order_item).to receive(:process)
+      subject.subscribe_to_task_updates
     end
   end
 end

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -1,25 +1,18 @@
 describe Catalog::UpdateOrderItem do
   describe "#process" do
-    around do |example|
-      ManageIQ::API::Common::Request.with_request(default_request) { example.call }
-    end
-
     let(:client) { double(:client) }
     let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client) }
     let(:payload) { {"task_id" => "123", "state" => state} }
+    let(:req) { { :headers => default_headers, :original_url => "localhost/nope" } }
     let!(:item) do
-      OrderItem.create!(
-        :count                       => 1,
-        :service_parameters          => "test",
-        :provider_control_parameters => "test",
-        :order                       => order,
-        :service_plan_ref            => "321",
-        :portfolio_item              => portfolio_item,
-        :topology_task_ref           => topology_task_ref
-      )
+      ManageIQ::API::Common::Request.with_request(req) do
+        create(:order_item,
+               :order_id          => order.id,
+               :topology_task_ref => topology_task_ref,
+               :portfolio_item_id => "1")
+      end
     end
-    let(:order) { Order.create! }
-    let(:portfolio_item) { PortfolioItem.create!(:service_offering_ref => "321") }
+    let(:order) { create(:order) }
     let(:subject) { described_class.new(topic) }
 
     context "when the order item is not findable" do

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -3,9 +3,8 @@ describe Catalog::UpdateOrderItem do
     let(:client) { double(:client) }
     let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client) }
     let(:payload) { {"task_id" => "123", "state" => state} }
-    let(:req) { { :headers => default_headers, :original_url => "localhost/nope" } }
     let!(:item) do
-      ManageIQ::API::Common::Request.with_request(req) do
+      ManageIQ::API::Common::Request.with_request(default_request) do
         create(:order_item,
                :order_id          => order.id,
                :topology_task_ref => topology_task_ref,

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -1,11 +1,7 @@
 describe Catalog::UpdateOrderItem do
   describe "#process" do
-    let(:request) do
-      { :headers => { 'x-rh-identity' => encoded_user_hash }, :original_url => 'whatever' }
-    end
-
     around do |example|
-      ManageIQ::API::Common::Request.with_request(request) { example.call }
+      ManageIQ::API::Common::Request.with_request(default_request) { example.call }
     end
 
     let(:client) { double(:client) }

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -1,0 +1,76 @@
+describe Catalog::UpdateOrderItem do
+  describe "#process" do
+    let(:request) do
+      { :headers => { 'x-rh-identity' => encoded_user_hash }, :original_url => 'whatever' }
+    end
+
+    around do |example|
+      ManageIQ::API::Common::Request.with_request(request) { example.call }
+    end
+
+    let(:client) { double(:client) }
+    let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client) }
+    let(:payload) { {"task_id" => "123", "state" => state} }
+    let!(:item) do
+      OrderItem.create!(
+        :count                       => 1,
+        :service_parameters          => "test",
+        :provider_control_parameters => "test",
+        :order                       => order,
+        :service_plan_ref            => "321",
+        :portfolio_item              => portfolio_item,
+        :topology_task_ref           => topology_task_ref
+      )
+    end
+    let(:order) { Order.create! }
+    let(:portfolio_item) { PortfolioItem.create!(:service_offering_ref => "321") }
+    let(:subject) { described_class.new(topic) }
+
+    context "when the order item is not findable" do
+      let(:topology_task_ref) { "0" }
+      let(:state) { "completed" }
+
+      it "raises an error" do
+        expect { subject.process }.to raise_error("Could not find an OrderItem with topology_task_ref: 123")
+      end
+    end
+
+    context "when the order item is findable" do
+      let(:topology_task_ref) { "123" }
+
+      context "when the state of the task is completed" do
+        let(:state) { "completed" }
+
+        it "creates a progress message about the payload" do
+          subject.process
+          latest_progress_message = ProgressMessage.second_to_last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+        end
+
+        it "updates the order item to be completed" do
+          subject.process
+          item.reload
+          expect(item.state).to eq("Order Completed")
+        end
+      end
+
+      context "when the state of the task is anything else" do
+        let(:state) { "test" }
+
+        it "creates a progress message about the payload" do
+          subject.process
+          latest_progress_message = ProgressMessage.last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+        end
+
+        it "does not update the order" do
+          subject.process
+          item.reload
+          expect(item.state).to eq("Created")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -8,4 +8,12 @@ module ServiceSpecHelper
       'x-rh-insights-request-id' => 'gobbledygook',
       'original_url'             => 'some_url' }
   end
+
+  def original_url
+    "whatever"
+  end
+
+  def default_request
+    { :headers => default_headers, :original_url => original_url }
+  end
 end


### PR DESCRIPTION
@mkanoor Is this what you're kind of thinking of so that we can adjust for tenants/request in this new class instead of having to worry about it in the `ServiceOrderListener`? `ProgressMessages` should be all of the form `order_item.update_message` now as well.