### PR TITLE
Use the routing helper from api common for major version redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,16 @@ Rails.application.routes.draw do
   # Disable PUT for now since rails sends these :update and they aren't really the same thing.
   def put(*_args); end
 
+  routing_helper = ManageIQ::API::Common::Routing.new(self)
+
   prefix = "api"
   if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   end
 
   scope :as => :api, :module => "api", :path => prefix do
-    match "/v1/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v1.0/%{path}", :only_path => true)
+    routing_helper.redirect_major_version("v1.0", prefix)
+
     namespace :v1x0, :path => "v1.0" do
       get "/openapi.json", :to => "root#openapi"
       post '/orders/:order_id/submit_order', :action => 'submit_order', :controller => 'orders', :as => 'order_submit_order'

--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ApplicationController, :type => :request do
 
     it "get api/v1/portfolios with tenant" do
       get("#{api_version}/portfolios/#{portfolio_id}", :headers => default_headers)
-      expect(response.status).to eq(301)
+      expect(response.status).to eq(302)
       expect(response.headers["Location"]).to eq "#{api_minor_version}/portfolios/#{portfolio_id}"
     end
 
@@ -26,7 +26,7 @@ RSpec.describe ApplicationController, :type => :request do
       headers = { "CONTENT_TYPE" => "application/json" }
 
       get("#{api_version}/portfolios/#{portfolio_id}", :headers => headers)
-      expect(response.status).to eq(301)
+      expect(response.status).to eq(302)
       expect(response.headers["Location"]).to eq "#{api_minor_version}/portfolios/#{portfolio_id}"
     end
   end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -6,5 +6,12 @@ describe "root", :type => :request do
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
     end
+
+    it "handles redirects correctly" do
+      get("/api/v1/openapi.json", :headers => default_headers)
+
+      expect(response.status).to eq(302)
+      expect(response.headers["Location"]).to eq("/api/v1.0/openapi.json")
+    end
   end
 end


### PR DESCRIPTION
This changes the redirect code from 301 to 302 and fixes an issue
where /openapi.json would redirect to /openapi

@miq-bot assign @Fryguy 