### PR TITLE
Move order_item context setting to only save if new_record

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -25,7 +25,7 @@ class OrderItem < ApplicationRecord
   belongs_to :portfolio_item
   has_many :progress_messages
   has_many :approval_requests, :dependent => :destroy
-  after_initialize :set_defaults, unless: :persisted?
+  before_create :set_defaults
 
   AS_JSON_ATTRIBUTES = %w(id order_id service_plan_ref portfolio_item_id state service_parameters
                           provider_control_parameters external_ref created_at ordered_at completed_at updated_at).freeze

--- a/spec/services/catalog/order_item_transition_spec.rb
+++ b/spec/services/catalog/order_item_transition_spec.rb
@@ -3,14 +3,16 @@ describe Catalog::OrderItemTransition do
   let(:submit_order) { instance_double(Catalog::SubmitOrder) }
   let(:topo_ex) { Catalog::TopologyError.new("boom") }
 
+  let(:req) { { :headers => default_headers, :original_url => "localhost/nope" } }
+
   let(:order) { create(:order) }
-  let(:order_item) do
-    create(:order_item,
-           :order_id          => order.id,
-           :portfolio_item_id => "1",
-           :context           => {
-             :headers => encoded_user_hash, :original_url => "localhost/nope"
-           })
+
+  let!(:order_item) do
+    ManageIQ::API::Common::Request.with_request(req) do
+      create(:order_item,
+             :order_id          => order.id,
+             :portfolio_item_id => "1")
+    end
   end
 
   let(:approval) do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-270

changed `after_initialize` callback to `before_create`, that way it'll only get called when creating the object and never called again. 