### PR TITLE
Enable rbac per tenant

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -3,7 +3,7 @@ module Api
     module Mixins
       module IndexMixin
         def scoped(relation)
-          #relation = rbac_scope(relation) if RBAC::Access.enabled?
+          relation = rbac_scope(relation) if RBAC::Access.enabled?
           if relation.model.respond_to?(:taggable?) && relation.model.taggable?
             ref_schema = {relation.model.tagging_relation_name => :tag}
 

--- a/db/migrate/20190406092520_add_enabled_to_tenant.rb
+++ b/db/migrate/20190406092520_add_enabled_to_tenant.rb
@@ -1,0 +1,5 @@
+class AddEnabledToTenant < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tenants, :rbac_enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_184014) do
+ActiveRecord::Schema.define(version: 2019_04_06_092520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_184014) do
     t.bigint "external_tenant"
     t.string "name"
     t.string "description"
+    t.boolean "rbac_enabled"
     t.index ["external_tenant"], name: "index_tenants_on_external_tenant"
   end
 

--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -30,7 +30,16 @@ module RBAC
     end
 
     def self.enabled?
-      ENV['BYPASS_RBAC'].blank?
+      enabled = ENV['BYPASS_RBAC'].blank?
+
+      # Temporary hack to allow per-tenant enabling of RBAC while we test
+      # TODO: Delete as soon as possible
+      if enabled == true
+        return enabled if ENV['RAILS_ENV'] == 'test'
+        enabled = false if ActsAsTenant.current_tenant.try(:rbac_enabled?) == false
+      end
+
+      enabled
     end
   end
 end

--- a/spec/requests/portfolios_rbac_spec.rb
+++ b/spec/requests/portfolios_rbac_spec.rb
@@ -7,7 +7,7 @@ describe 'Portfolios RBAC API' do
   let(:block_access_obj) { instance_double(RBAC::Access, :accessible? => false) }
 
   describe "GET /portfolios" do
-    xit 'returns status code 200' do
+    it 'returns status code 200' do
       allow(RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)
       get "#{api('1.0')}/portfolios", :headers => default_headers
@@ -17,7 +17,7 @@ describe 'Portfolios RBAC API' do
       expect(result['data'][0]['id']).to eq(portfolio1.id.to_s)
     end
 
-    xit 'returns status code 403' do
+    it 'returns status code 403' do
       allow(RBAC::Access).to receive(:new).with('portfolios', 'read').and_return(block_access_obj)
       allow(block_access_obj).to receive(:process).and_return(block_access_obj)
       get "#{api('1.0')}/portfolios", :headers => default_headers


### PR DESCRIPTION
Just an idea on how we can progressively rollout RBAC for each tenant/environment while we continue to test.  Default is that it is disabled.  Woud use the Rails console to update the tenant flag.

Ultimate goal is to remove the logic as soon as possible.

cc @lindgrenj6 @lgalis 