### PR TITLE
Removed bypassing tenancy code

### DIFF
--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe ApplicationController, :type => :request do
-
   let(:tenant)            { Tenant.create(:external_tenant => external_tenant) }
   let(:portfolio)         { Portfolio.create!(:name => 'tenant_portfolio', :description => 'tenant desc', :tenant_id => tenant.id, :owner => 'wilma') }
   let(:portfolio_id)      { portfolio.id }
@@ -39,7 +38,7 @@ RSpec.describe ApplicationController, :type => :request do
     end
 
     it "get /portfolios with tenant" do
-      get("/api/v1.0/portfolios/#{portfolio_id}", :headers => admin_headers)
+      get("/api/v1.0/portfolios/#{portfolio_id}", :headers => default_headers)
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to include("id" => portfolio_id.to_s)

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -1,11 +1,12 @@
 describe Catalog::CreateApprovalRequest do
   let(:create_approval_request) { described_class.new(order.id) }
 
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
   let(:workflow_ref) { "1" }
-  let!(:order) { create(:order) }
-  let!(:portfolio) { create(:portfolio) }
-  let!(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :workflow_ref => workflow_ref) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => 1) }
+  let!(:order) { create(:order, :tenant_id => tenant.id) }
+  let!(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :workflow_ref => workflow_ref, :tenant_id => tenant.id) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
 
   let(:approval) { class_double(Approval).as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { instance_double(ApprovalApiClient::RequestApi) }

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -3,14 +3,6 @@ module ServiceSpecHelper
     ClimateControl.modify(options, &block)
   end
 
-  def admin_headers
-    default_headers
-  end
-
-  def user_headers
-    default_headers
-  end
-
   def default_headers
     { 'x-rh-identity' => encoded_user_hash }
   end


### PR DESCRIPTION
We pass the default_headers which has the x-rh-identity so we dont
need to bypass tenancy anymore

Fixes #212 