### PR TITLE
Check if the user has write access to Portfolio

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1x0
+    module Mixins
+      module RBACMixin
+        def write_access_check
+          return unless RBAC::Access.enabled?
+          access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, 'write').process
+          raise Catalog::NotAuthorized, "Write access not authorized for #{controller_name.classify.constantize}" unless access_obj.accessible?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -3,20 +3,19 @@ module Api
     class PortfoliosController < ApplicationController
       include Api::V1x0::Mixins::IndexMixin
       include Api::V1x0::Mixins::RBACMixin
+      before_action :write_access_check, :only => %i(add_portfolio_item_to_portfolio create update destroy)
 
       def index
         collection(Portfolio.all)
       end
 
       def add_portfolio_item_to_portfolio
-        write_access_check
         portfolio = Portfolio.find(params.require(:portfolio_id))
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
         render :json => portfolio.add_portfolio_item(portfolio_item)
       end
 
       def create
-        write_access_check
         portfolio = Portfolio.create!(portfolio_params)
         render :json => portfolio
       rescue ActiveRecord::RecordInvalid => e
@@ -24,7 +23,6 @@ module Api
       end
 
       def update
-        write_access_check
         portfolio = Portfolio.find(params.require(:id))
         portfolio.update!(portfolio_params)
 
@@ -39,7 +37,6 @@ module Api
       end
 
       def destroy
-        write_access_check
         portfolio = Portfolio.find(params.require(:id))
         if portfolio.discard
           head :no_content

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -2,18 +2,21 @@ module Api
   module V1x0
     class PortfoliosController < ApplicationController
       include Api::V1x0::Mixins::IndexMixin
+      include Api::V1x0::Mixins::RBACMixin
 
       def index
         collection(Portfolio.all)
       end
 
       def add_portfolio_item_to_portfolio
+        write_access_check
         portfolio = Portfolio.find(params.require(:portfolio_id))
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
         render :json => portfolio.add_portfolio_item(portfolio_item)
       end
 
       def create
+        write_access_check
         portfolio = Portfolio.create!(portfolio_params)
         render :json => portfolio
       rescue ActiveRecord::RecordInvalid => e
@@ -21,6 +24,7 @@ module Api
       end
 
       def update
+        write_access_check
         portfolio = Portfolio.find(params.require(:id))
         portfolio.update!(portfolio_params)
 
@@ -35,6 +39,7 @@ module Api
       end
 
       def destroy
+        write_access_check
         portfolio = Portfolio.find(params.require(:id))
         if portfolio.discard
           head :no_content

--- a/spec/requests/portfolios_rbac_write_access_spec.rb
+++ b/spec/requests/portfolios_rbac_write_access_spec.rb
@@ -1,0 +1,27 @@
+describe 'Portfolios Write Access RBAC API' do
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:access_obj) { instance_double(RBAC::Access, :accessible? => true) }
+  let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
+
+  let(:block_access_obj) { instance_double(RBAC::Access, :accessible? => false) }
+
+  describe "POST /portfolios" do
+    it 'creates a portfolio' do
+      allow(RBAC::Access).to receive(:new).with('portfolios', 'write').and_return(access_obj)
+      allow(access_obj).to receive(:process).and_return(access_obj)
+      post "#{api('1.0')}/portfolios", :headers => default_headers, :params => valid_attributes
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns status code 403' do
+      allow(RBAC::Access).to receive(:new).with('portfolios', 'write').and_return(block_access_obj)
+      allow(block_access_obj).to receive(:process).and_return(block_access_obj)
+      post "#{api('1.0')}/portfolios", :headers => default_headers, :params => valid_attributes
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
Prevent a user with read-only access from creating a new Portfolio.

The Catalog Administrators group have write access to the portfolios
The Catalog Users group don't have write access to the portfolios
The permission looks like `catalog:portfolios:write`

This addresses the issue of a Catalog User creating a Portfolio and it is removed from their view till the Catalog Administrator shares it with the user.