### PR TITLE
Add external url to order items on task update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem 'rspec-mocks'
   gem 'rspec-rails'
   gem 'simplecov'
+  gem 'webmock'
 end
 
 group :development do

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -47,11 +47,8 @@ module Catalog
     def fetch_external_url
       TopologicalInventory.call do |api_instance|
         task = api_instance.show_task(@payload["task_id"])
-        service_instance_response = api_instance.api_client.call_api(
-          :GET,
-          JSON.parse(task.context)["service_instance"]["url"],
-          :return_type => "ServiceInstance")
-        return service_instance_response[0].external_url if service_instance_response[1] == 200
+        service_instance = api_instance.show_service_instance(JSON.parse(task.context)["service_instance"]["id"])
+        service_instance.external_url
       end
     rescue Catalog::TopologyError
       Rails.logger.error("Could not find the service instance attached to task_id: #{@payload["task_id"]}")

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -21,10 +21,9 @@ module Catalog
           order_item.state = "Order Completed"
           order_item.update_message("info", "Order Complete")
 
-          external_url = fetch_external_url
-          order_item.external_url = external_url
+          order_item.external_url = fetch_external_url
 
-          Rails.logger.info("Updating OrderItem: #{order_item.id} with 'Order Completed' state and #{external_url}")
+          Rails.logger.info("Updating OrderItem: #{order_item.id} with 'Order Completed' state and #{order_item.external_url}")
           order_item.save!
           Rails.logger.info("Finished updating OrderItem: #{order_item.id} with 'Order Completed' state")
         end

--- a/db/migrate/20190409143525_add_external_url_to_order_items.rb
+++ b/db/migrate/20190409143525_add_external_url_to_order_items.rb
@@ -1,0 +1,5 @@
+class AddExternalUrlToOrderItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_items, :external_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_184014) do
+ActiveRecord::Schema.define(version: 2019_04_09_143525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_184014) do
     t.jsonb "provider_control_parameters"
     t.jsonb "context"
     t.string "owner"
+    t.string "external_url"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end
 

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -28,7 +28,7 @@ describe Catalog::UpdateOrderItem do
 
       context "when the state of the task is completed" do
         let(:state) { "completed" }
-        let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:url => "service_instance_url"}}.to_json) }
+        let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => "321"}}.to_json) }
         let(:service_instance) { TopologicalInventoryApiClient::ServiceInstance.new(:external_url => "external url") }
 
         around do |e|
@@ -48,7 +48,7 @@ describe Catalog::UpdateOrderItem do
 
         context "when the service instance can be found" do
           before do
-            stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instance_url").
+            stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
               with(:headers => {'Content-Type'=>'application/json'}).
               to_return(:status => 200, :body => service_instance.to_json, :headers => {})
           end
@@ -75,7 +75,7 @@ describe Catalog::UpdateOrderItem do
 
         context "when the service instance can not be found" do
           before do
-            stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instance_url").
+            stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
               with(:headers => {'Content-Type'=>'application/json'}).
               to_return(:status => 404, :body => service_instance.to_json, :headers => {})
           end

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -26,19 +26,16 @@ describe Catalog::UpdateOrderItem do
     context "when the order item is findable" do
       let(:topology_task_ref) { "123" }
 
+      around do |e|
+        with_modified_env :TOPOLOGICAL_INVENTORY_URL => 'http://localhost:3000' do
+          e.run
+        end
+      end
+
       context "when the state of the task is completed" do
         let(:state) { "completed" }
         let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => "321"}}.to_json) }
         let(:service_instance) { TopologicalInventoryApiClient::ServiceInstance.new(:external_url => "external url") }
-
-        around do |e|
-          url = ENV["TOPOLOGICAL_INVENTORY_URL"]
-          ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-
-          e.run
-
-          ENV["TOPOLOGICAL_INVENTORY_URL"] = url
-        end
 
         before do
           stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/tasks/123").

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -73,15 +73,15 @@ describe Catalog::UpdateOrderItem do
           end
         end
 
-        context "when the service instance can not be found" do
+        context "when the service instance does not have an external url" do
           before do
             stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
               with(:headers => {'Content-Type'=>'application/json'}).
-              to_return(:status => 404, :body => service_instance.to_json, :headers => {})
+              to_return(:status => 200, :body => "".to_json, :headers => {})
           end
 
           it "raises an error" do
-            expect { subject.process }.to raise_error("Could not find a ServiceInstance attached to task_id: 123")
+            expect { subject.process }.to raise_error("Could not find an external url on service instance (id: 321) attached to task_id: 123")
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'webmock/rspec'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 Dir[ManageIQ::API::Common::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -1,5 +1,6 @@
 module ServiceSpecHelper
   def with_modified_env(options, &block)
+    Thread.current[:api_instance] = nil
     ClimateControl.modify(options, &block)
   end
 


### PR DESCRIPTION
This was built on top of https://github.com/ManageIQ/catalog-api/pull/201 so that will need to be merged first and then this rebased. It should be easier to review once that is merged, or if only looking at the latest commit.

This also assumes that the `task.context["service_instance"]["url"]` is the correct url for the service instance. It *should* be, according to https://github.com/ManageIQ/topological_inventory-openshift/blob/master/lib/topological_inventory/openshift/operations/processor.rb#L88, but if it's not, the api call will need to change to use the `source_id` and `source_ref` with filters.

@syncrou Please Review