### PR TITLE
Change from 404 to 422 response for blank parameters on /portfolio_items subresources

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::API
     ManageIQ::API::Common::Request.with_request(request) do |current|
       begin
         ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
-      rescue KeyError
+      rescue ManageIQ::API::Common::IdentityError
         json_response({ :message => 'Unauthorized' }, :unauthorized)
       rescue Catalog::NoTenantError
         json_response({ :message => 'Unauthorized' }, :unauthorized)

--- a/config/initializers/http_rescue_responses.rb
+++ b/config/initializers/http_rescue_responses.rb
@@ -1,0 +1,1 @@
+ActionDispatch::ExceptionWrapper.rescue_responses["ActionController::ParameterMissing"] = :unprocessable_entity


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-241
https://projects.engineering.redhat.com/browse/SSP-242
https://projects.engineering.redhat.com/browse/SSP-244

Rescues from `ActionController::ParameterMissing` exception when path parameters aren't present. 

This can only be thrown when a blank parameter is passed on the path, like this:
`/portfolios/" "/portfolio_items`