### PR TITLE
Expose 'external_url' property to the API for OrderItems

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -15,7 +15,7 @@ class OrderItem < ApplicationRecord
   has_many :approval_requests, :dependent => :destroy
   before_create :set_defaults
 
-  AS_JSON_ATTRIBUTES = %w(id order_id service_plan_ref portfolio_item_id state service_parameters
+  AS_JSON_ATTRIBUTES = %w(id order_id service_plan_ref portfolio_item_id state service_parameters external_url
                           provider_control_parameters external_ref created_at ordered_at completed_at updated_at).freeze
 
   def as_json(_options = {})

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1423,6 +1423,11 @@
             "type": "string",
             "title": "Owner",
             "example": "jdoe"
+          },
+          "external_url": {
+            "type": "string",
+            "title": "External url",
+            "description": "The external url of the service instance used with relation to this order item"
           }
         }
       },


### PR DESCRIPTION
As discussed in #221, the `external_url` property should be exposed through the API.

@syncrou Please Review