### PR TITLE
Change OrderID to string in ApprovalRequest content object

### DIFF
--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -37,7 +37,7 @@ module Catalog
         request.content   = {
           :product   => order_item.portfolio_item.name,
           :portfolio => order_item.portfolio_item.portfolio.name,
-          :order_id  => order_item.order_id,
+          :order_id  => order_item.order_id.to_s,
           :params    => svc_params_sanitized
         }
       end

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -97,7 +97,7 @@ describe Catalog::CreateApprovalRequest do
         expect(req.name).to eq order_item.portfolio_item.name
         expect(req.content).to include(:product   => order_item.portfolio_item.name,
                                        :portfolio => order_item.portfolio_item.portfolio.name,
-                                       :order_id  => order_item.order_id,
+                                       :order_id  => order_item.order_id.to_s,
                                        :params    => hashy)
       end
     end


### PR DESCRIPTION
Martin M. pointed out that we're returning an integer for the order_id in the ApprovalRequests content object - this just changes that to a string so that we are consistent.