### PR TITLE
Disabling write_access_check for the show_mixin

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -3,9 +3,9 @@ module Api
     module Mixins
       module RBACMixin
         def write_access_check
-          return unless RBAC::Access.enabled?
-          access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, 'write').process
-          raise Catalog::NotAuthorized, "Write access not authorized for #{controller_name.classify.constantize}" unless access_obj.accessible?
+          return #unless RBAC::Access.enabled?
+          #access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, 'write').process
+          #raise Catalog::NotAuthorized, "Write access not authorized for #{controller_name.classify.constantize}" unless access_obj.accessible?
         end
       end
     end

--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -30,7 +30,7 @@ module RBAC
       ENV['BYPASS_RBAC'].blank?
     end
 
-    private 
+    private
     def collect_ids
       @acl.collect do |item|
         item.resource_definitions.collect do |rd|

--- a/spec/requests/portfolios_rbac_write_access_spec.rb
+++ b/spec/requests/portfolios_rbac_write_access_spec.rb
@@ -16,7 +16,7 @@ describe 'Portfolios Write Access RBAC API' do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'returns status code 403' do
+    xit 'returns status code 403' do
       allow(RBAC::Access).to receive(:new).with('portfolios', 'write').and_return(block_access_obj)
       allow(block_access_obj).to receive(:process).and_return(block_access_obj)
       post "#{api('1.0')}/portfolios", :headers => default_headers, :params => valid_attributes


### PR DESCRIPTION
Following the same pattern used in the `index_mixin` in the `show_mixin`, just commenting out the code that applies the RBAC ( in this case just returning )