### PR TITLE
Spec cleanup

### DIFF
--- a/spec/lib/approval_request_listener_spec.rb
+++ b/spec/lib/approval_request_listener_spec.rb
@@ -16,9 +16,7 @@ describe ApprovalRequestListener do
       create(:order_item,
              :order_id          => order.id,
              :portfolio_item_id => "234",
-             :context           => {
-               :headers => encoded_user_hash, :original_url => "localhost/nope"
-             })
+             :context           => default_request)
     end
     let!(:approval_request) do
       ApprovalRequest.create!(

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -23,10 +23,7 @@ describe Catalog::AddToOrder do
 
   let(:order_item) { described_class.new(params).process.order.order_items.first }
 
-  let(:encoded) { encoded_user_hash }
-  let(:request) do
-    { :headers => { 'x-rh-identity' => encoded }, :original_url => 'whatever' }
-  end
+  let(:request) { default_request }
 
   it "add order item" do
     ManageIQ::API::Common::Request.with_request(request) do
@@ -48,7 +45,7 @@ describe Catalog::AddToOrder do
   context "when passing in a x-rh-identity header" do
     it 'sets the context to the encoded_user_hash' do
       ManageIQ::API::Common::Request.with_request(request) do
-        expect(order_item.context["headers"]["x-rh-identity"]).to eq encoded
+        expect(order_item.context["headers"]["x-rh-identity"]).to eq encoded_user_hash
       end
     end
 

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -11,9 +11,7 @@ describe Catalog::SubmitOrder do
                         :provider_control_parameters => provider_control_parameters,
                         :order_id                    => order.id,
                         :count                       => 1,
-                        :context                     => {
-                          :headers => encoded_user_hash, :original_url => "localhost/nope"
-                        })
+                        :context                     => default_request)
   end
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
   let(:portfolio_item_id) { portfolio_item.id.to_s }

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -6,8 +6,7 @@ module ServiceSpecHelper
 
   def default_headers
     { 'x-rh-identity'            => encoded_user_hash,
-      'x-rh-insights-request-id' => 'gobbledygook',
-      'original_url'             => 'some_url' }
+      'x-rh-insights-request-id' => 'gobbledygook' }
   end
 
   def original_url


### PR DESCRIPTION
* Don't create the encoded_user_hash in spec, use the one from default
_headers or default_request
* original_url is part of the request and not headers