### PR TITLE
Fixed logic and spec coverage

### DIFF
--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -44,7 +44,6 @@ module ServiceOffering
       # Fill up empty fields if they're empty with fields we already have, this is really easy with the ||= and subsequent || operators
       @params[:long_description] ||= @params[:description] || @params[:display_name]
       @params[:display_name] ||= @params[:name]
-      @params[:owner] = ManageIQ::API::Common::Request.current.user.username
       @params
     end
   end

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -2,7 +2,6 @@ module ServiceOffering
   class AddToPortfolioItem
     IGNORE_FIELDS = %w(id created_at updated_at portfolio_id tenant_id).freeze
 
-    attr_reader :params
     attr_reader :item
 
     def initialize(params)
@@ -33,7 +32,7 @@ module ServiceOffering
 
     def generate_attributes
       creation_fields.each do |column|
-        @params[column] = @service_offering.send(column) if @service_offering.send(column).present?
+        @params[column] ||= @service_offering.send(column) if @service_offering.send(column).present?
       end
       populate_missing_fields
     end
@@ -45,6 +44,7 @@ module ServiceOffering
       # Fill up empty fields if they're empty with fields we already have, this is really easy with the ||= and subsequent || operators
       @params[:long_description] ||= @params[:description] || @params[:display_name]
       @params[:display_name] ||= @params[:name]
+      @params[:owner] = ManageIQ::API::Common::Request.current.user.username
       @params
     end
   end

--- a/spec/support/service_offering_topological_service_offering_helper.rb
+++ b/spec/support/service_offering_topological_service_offering_helper.rb
@@ -1,7 +1,7 @@
 module ServiceOfferingHelper
   def fully_populated_service_offering
     TopologicalInventoryApiClient::ServiceOffering.new(
-      :id                       => 1,
+      :id                       => "1",
       :name                     => "test name",
       :description              => "test description",
       :source_ref               => '123',
@@ -11,7 +11,7 @@ module ServiceOfferingHelper
       :documentation_url        => "http://test.docs.io",
       :support_url              => "800-555-TEST",
       :distributor              => "Red Hat Inc.",
-      :service_offering_icon_id => 998
+      :service_offering_icon_id => "998"
     )
   end
 


### PR DESCRIPTION
- The parameters passed in from caller were being overridden
- The spec was testing private methods
- 100% coverage on code
- Was missing the owner name because the spec didn't use the with_request do block
<img width="820" alt="Screen Shot 2019-04-12 at 7 54 49 PM" src="https://user-images.githubusercontent.com/6452699/56044489-eb71f800-5d5c-11e9-8259-f8da2a0f7612.png">
