### PR TITLE
Filter Error handling now assumes we will always have a tenant

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,17 +14,12 @@ class ApplicationController < ActionController::API
         ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
       rescue ManageIQ::API::Common::IdentityError
         json_response({ :message => 'Unauthorized' }, :unauthorized)
-      rescue Catalog::NoTenantError
-        json_response({ :message => 'Unauthorized' }, :unauthorized)
       end
     end
   end
 
   def current_tenant(current_user)
-    tenant = current_user.tenant
-    found_tenant = Tenant.find_or_create_by(:external_tenant => tenant) if tenant.present?
-    return found_tenant if found_tenant
-    raise Catalog::NoTenantError
+    Tenant.find_or_create_by(:external_tenant => current_user.tenant)
   end
 
   def topology_service_error(err)

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,7 +1,6 @@
 module Catalog
   class TopologyError < StandardError; end
   class RBACError < StandardError; end
-  class NoTenantError < StandardError; end
   class ApprovalError < StandardError; end
   class NotAuthorized < StandardError; end
 end


### PR DESCRIPTION
Pulled out the allowance for a nil current_user. The common gem or the filter should handle
the lookup correctly and handle error handling if there is an issue