### PR TITLE
Fixed the strong parameters warning

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -16,8 +16,8 @@ module Api
           render :json => ManageIQ::API::Common::PaginatedResponse.new(
             :base_query => scoped(base_query),
             :request    => request,
-            :limit      => params.permit(:limit)[:limit],
-            :offset     => params.permit(:offset)[:offset]
+            :limit      => pagination_params[:limit],
+            :offset     => pagination_params[:offset]
           ).response
         end
 
@@ -26,6 +26,10 @@ module Api
           raise Catalog::NotAuthorized, "Not Authorized for #{relation.model}" unless access_obj.accessible?
           ids = access_obj.id_list
           ids.any? ? relation.where(:id => ids) : relation
+        end
+
+        def pagination_params
+          params.permit(:limit, :offset)
         end
       end
     end


### PR DESCRIPTION
When the permit method is used, its arguments should contain all
the allowed parameters. Prior to this each permit was only passing
only 1 parameter, and a warning get reported for the other variable

Fixes https://github.com/ManageIQ/catalog-api/issues/132