### PR TITLE
Update OpenApi Spec to v1.0

### DIFF
--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "description": "This API gets and orders catalog items from different cloud sources.",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "title": "Catalog API",
     "contact": {
       "email": "support@redhat.com"


### PR DESCRIPTION
Noticed we are still using 0.1.0 in our openapi spec, updated to 1.0.