### PR TITLE
Can only update specific portfolios

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -3,9 +3,11 @@ module Api
     module Mixins
       module RBACMixin
         def write_access_check
-        return unless RBAC::Access.enabled?
-        access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, 'write').process
-        raise Catalog::NotAuthorized, "Write access not authorized for #{controller_name.classify.constantize}" unless access_obj.accessible?
+          return unless RBAC::Access.enabled?
+          access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, 'write').process
+          raise Catalog::NotAuthorized, "Write access not authorized for #{controller_name.classify.constantize}" unless access_obj.accessible?
+          ids = access_obj.id_list
+          raise Catalog::NotAuthorized, "Write access not authorized for #{controller_name.classify.constantize}" if ids.any? && ids.exclude?(params[:id])
         end
       end
     end

--- a/spec/requests/portfolios_rbac_write_access_spec.rb
+++ b/spec/requests/portfolios_rbac_write_access_spec.rb
@@ -2,9 +2,10 @@ describe 'Portfolios Write Access RBAC API' do
   let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
   let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
-  let(:access_obj) { instance_double(RBAC::Access, :accessible? => true) }
+  let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :id_list => id_list) }
   let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
-
+  let(:updated_attributes) { {:name => 'Barney', :description => "Barney's Portfolio" } }
+  let(:id_list) { [] }
   let(:block_access_obj) { instance_double(RBAC::Access, :accessible? => false) }
 
   describe "POST /portfolios" do
@@ -21,6 +22,25 @@ describe 'Portfolios Write Access RBAC API' do
       allow(block_access_obj).to receive(:process).and_return(block_access_obj)
       post "#{api('1.0')}/portfolios", :headers => default_headers, :params => valid_attributes
 
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "PATCH /portfolios" do
+    let(:id_list) { [portfolio1.id.to_s] }
+
+    before do
+      allow(RBAC::Access).to receive(:new).with('portfolios', 'write').and_return(access_obj)
+      allow(access_obj).to receive(:process).and_return(access_obj)
+    end
+
+    it 'only allows updating a specific portfolio' do
+      patch "#{api('1.0')}/portfolios/#{portfolio1.id}", :headers => default_headers, :params => updated_attributes
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'fails updating a portfolio' do
+      patch "#{api('1.0')}/portfolios/#{portfolio2.id}", :headers => default_headers, :params => updated_attributes
       expect(response).to have_http_status(:forbidden)
     end
   end


### PR DESCRIPTION
With Sharing an administrator can share a portfolio with specific
groups for Editing/Updating. This PR allows only the specific
portfolio to be updated, the rest would return a forbidden