### PR TITLE
Add filtering from common gem

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -14,7 +14,7 @@ module Api
 
         def collection(base_query)
           render :json => ManageIQ::API::Common::PaginatedResponse.new(
-            :base_query => scoped(base_query),
+            :base_query => filtered(scoped(base_query)),
             :request    => request,
             :limit      => pagination_params[:limit],
             :offset     => pagination_params[:offset]
@@ -32,6 +32,28 @@ module Api
 
         def pagination_params
           params.permit(:limit, :offset)
+        end
+
+        def filtered(base_query)
+          ManageIQ::API::Common::Filter.new(base_query, params[:filter], api_doc_definition).apply
+        end
+
+        private
+
+        def api_doc_definition
+          @api_doc_definition ||= Api::Docs[api_version].definitions[model_name]
+        end
+
+        def api_version
+          @api_version ||= name.split("::")[1].downcase.delete("v").sub("x", ".")
+        end
+
+        def model_name
+          @model_name ||= controller_name.classify
+        end
+
+        def name
+          self.class.to_s
         end
       end
     end

--- a/lib/api/docs.rb
+++ b/lib/api/docs.rb
@@ -1,0 +1,3 @@
+module Api
+  Docs = ManageIQ::API::Common::OpenApi::Docs.new(Dir.glob(Rails.root.join("public", "**", "openapi*.json")))
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-308

Implement REST filtering via `ManageIQ::API::Common::Filter`, ended up adding `Api::Docs` as well so we can get information from our OpenAPI Documentation.

- [x] Add tests
- [x] Filtering documentation https://github.com/ManageIQ/manageiq-api-common/pull/57
