### PR TITLE
Finalize order after order_item is marked as finished

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -31,49 +31,4 @@ class OrderItem < ApplicationRecord
     progress_messages << ProgressMessage.new(:level => level, :message => message, :tenant_id => self.tenant_id)
     touch
   end
-
-  def monitor
-    prov = Provider.find(provider_id)
-    reason = "Provisioning"
-    inflight = %w(Provisioning ProvisionRequestInFlight)
-    parsed_data = {}
-    while inflight.include?(reason) do
-      sleep(5)
-      response = prov.service_status(external_ref)
-      parsed_data = JSON.parse(response.body)
-      async = parsed_data['status']['asyncOpInProgress']
-
-      message = parsed_data['status']['conditions'][0]['message']
-      # puts "Status : #{parsed_data['status']['conditions'][0]['status']}"
-      # puts "Type : #{parsed_data['status']['conditions'][0]['type']}"
-      reason = parsed_data['status']['conditions'][0]['reason']
-      level = reason == 'ProvisionCallFailed' ? 'error' : 'info'
-      update_message(level, message)
-    end
-    set_final_state(reason)
-    order.finalize_order
-  end
-
-  def set_final_state(reason)
-    case reason
-    when "ProvisionCallFailed"
-      mark_failed
-    when "ProvisionedSuccessfully"
-      mark_finished
-    else
-      mark_finished
-    end
-  end
-
-  def mark_failed
-    self.completed_at = DateTime.now
-    self.state = 'Failed'
-    save!
-  end
-
-  def mark_finished
-    self.completed_at = DateTime.now
-    self.state = 'Completed'
-    save!
-  end
 end

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -105,7 +105,7 @@ describe Catalog::UpdateOrderItem do
         end
       end
 
-      context "when the status of the task is anything else" do
+      context "when the status of the task is error" do
         let(:status) { "error" }
 
         it "creates a progress message about the payload" do
@@ -141,6 +141,17 @@ describe Catalog::UpdateOrderItem do
           subject.process
           order.reload
           expect(order.state).to eq("Failed")
+        end
+      end
+
+      context "when the status of the task is anything else" do
+        let(:status) { "foo" }
+
+        it "creates a progress message about the payload" do
+          subject.process
+          latest_progress_message = ProgressMessage.last
+          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
         end
       end
     end

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -135,6 +135,13 @@ describe Catalog::UpdateOrderItem do
           expect(latest_progress_message.level).to eq("info")
           expect(latest_progress_message.message).to eq("Order Item Failed")
         end
+
+        it "finalizes the order" do
+          expect(order.state).to_not eq("Failed")
+          subject.process
+          order.reload
+          expect(order.state).to eq("Failed")
+        end
       end
     end
   end

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -57,16 +57,31 @@ describe Catalog::UpdateOrderItem do
             expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
           end
 
+          it "updates the completed at time" do
+            fake_now = DateTime.now
+            allow(DateTime).to receive(:now).and_return(fake_now)
+            subject.process
+            item.reload
+            expect(item.completed_at).to eq(fake_now)
+          end
+
           it "updates the order item to be completed" do
             subject.process
             item.reload
-            expect(item.state).to eq("Order Completed")
+            expect(item.state).to eq("Completed")
           end
 
           it "updates the order item with the external url" do
             subject.process
             item.reload
             expect(item.external_url).to eq("external url")
+          end
+
+          it "finalizes the order" do
+            expect(order.state).to_not eq("Completed")
+            subject.process
+            order.reload
+            expect(order.state).to eq("Completed")
           end
         end
 


### PR DESCRIPTION
As mentioned in #223, we need to finalize the order after the order item is completed, so this PR does that and moves the updating code into a private method.

WIP since I think we can pull out some of the code in the order_item and order models but need to confirm with @mkanoor and @syncrou first.