### PR TITLE
Add default_scope to Order model to sort by created_at, descending

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,8 @@ class Order < ApplicationRecord
   include OwnerField
   acts_as_tenant(:tenant)
 
+  default_scope { order(:created_at => :desc) }
+
   has_many :order_items
 
   after_initialize :set_defaults, unless: :persisted?


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-320

Add a default scope to Order so that it returns the models ordered descending by `created_at`, so it shows the newest ones first.