### PR TITLE
Remove explicit rescue in favor of `rescue_from` error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,11 +10,7 @@ class ApplicationController < ActionController::API
 
   def with_current_request
     ManageIQ::API::Common::Request.with_request(request) do |current|
-      begin
-        ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
-      rescue ManageIQ::API::Common::IdentityError
-        json_response({ :message => 'Unauthorized' }, :unauthorized)
-      end
+      ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
     end
   end
 


### PR DESCRIPTION
Found this while looking around in the application controller, we're already doing a `recue_from` for MIQ::Common::IdentityError, so we don't need to begin/rescue it and throw unauthorized, the `rescue_from` handles that for us.