### PR TITLE
Refactor move ApplicationController#*_error methods to Response mixin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,16 +21,4 @@ class ApplicationController < ActionController::API
   def current_tenant(current_user)
     Tenant.find_or_create_by(:external_tenant => current_user.tenant)
   end
-
-  def topology_service_error(err)
-    render :json => {:message => err.message}, :status => :internal_server_error
-  end
-
-  def forbidden_error(err)
-    render :json => {:message => err.message}, :status => :forbidden
-  end
-
-  def unauthorized_error(err)
-    render :json => {:message => err.message}, :status => :unauthorized
-  end
 end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -2,4 +2,18 @@ module Response
   def json_response(object, status = :ok)
     render :json => object, :status => status
   end
+
+  def topology_service_error(err)
+    render :json => {:message => err.message}, :status => :internal_server_error
+  end
+
+  def forbidden_error(err)
+    Rails.logger.error("Forbidden error: #{err.message}")
+    render :json => {:message => "Forbidden"}, :status => :forbidden
+  end
+
+  def unauthorized_error(err)
+    Rails.logger.error("Unauthorized error: #{err.message}")
+    render :json => {:message => "Unauthorized"}, :status => :unauthorized
+  end
 end


### PR DESCRIPTION
When working in the application controller it seems it's getting a bit busy with this boilerplate stuff, so I moved the *_error methods to the `Response` mixin since they're technically responses. That way the response related things are all contained in the mixin rather than in the ApplicationController.