### PR TITLE
Add by_owner scope to ProgressMessages and ApprovalRequests

### DIFF
--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -6,8 +6,8 @@ class ApprovalRequest < ApplicationRecord
   belongs_to :order_item
 
   scope :by_owner, lambda {
-    joins(:order_item)
-      .select("approval_requests.*, order_items.owner")
-      .where("order_items.owner = ?", ManageIQ::API::Common::Request.current.user.username)
+    joins("INNER JOIN order_items ON (order_items.id = approval_requests.order_item_id::int)")
+      .joins("INNER JOIN orders ON (orders.id = order_items.order_id::int)")
+      .where("orders.owner = ?", ManageIQ::API::Common::Request.current.user.username)
   }
 end

--- a/app/models/approval_request.rb
+++ b/app/models/approval_request.rb
@@ -4,4 +4,10 @@ class ApprovalRequest < ApplicationRecord
   enum :state => [:undecided, :approved, :denied]
 
   belongs_to :order_item
+
+  scope :by_owner, lambda {
+    joins(:order_item)
+      .select("approval_requests.*, order_items.owner")
+      .where("order_items.owner = ?", ManageIQ::API::Common::Request.current.user.username)
+  }
 end

--- a/app/models/progress_message.rb
+++ b/app/models/progress_message.rb
@@ -7,8 +7,8 @@ class ProgressMessage < ApplicationRecord
 
   scope :by_owner, lambda {
     joins("INNER JOIN order_items ON (order_items.id = progress_messages.order_item_id::int)")
-      .select("progress_messages.*, order_items.owner")
-      .where("order_items.owner = ?", ManageIQ::API::Common::Request.current.user.username)
+      .joins("INNER JOIN orders ON (orders.id = order_items.order_id::int)")
+      .where("orders.owner = ?", ManageIQ::API::Common::Request.current.user.username)
   }
 
   def as_json(_options = {})

--- a/app/models/progress_message.rb
+++ b/app/models/progress_message.rb
@@ -5,6 +5,12 @@ class ProgressMessage < ApplicationRecord
 
   AS_JSON_ATTRIBUTES = %w(id level message received_at).freeze
 
+  scope :by_owner, lambda {
+    joins("INNER JOIN order_items ON (order_items.id = progress_messages.order_item_id::int)")
+      .select("progress_messages.*, order_items.owner")
+      .where("order_items.owner = ?", ManageIQ::API::Common::Request.current.user.username)
+  }
+
   def as_json(_options = {})
     super.slice(*AS_JSON_ATTRIBUTES)
   end

--- a/spec/models/approval_request_spec.rb
+++ b/spec/models/approval_request_spec.rb
@@ -1,0 +1,27 @@
+describe ApprovalRequest, :type => :model do
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
+  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
+  let!(:approval_request1) { create(:approval_request, :order_item_id => order_item1.id) }
+  let!(:approval_request2) { create(:approval_request, :order_item_id => order_item2.id) }
+
+  around do |example|
+    ManageIQ::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  context "by_owner" do
+    let(:results) { ApprovalRequest.by_owner }
+
+    before do
+      order_item2.update!(:owner => "not_jdoe")
+    end
+
+    it "only has one result" do
+      expect(results.size).to eq 1
+    end
+
+    it "filters by the owner" do
+      expect(results.first.owner).to eq "jdoe"
+    end
+  end
+end

--- a/spec/models/approval_request_spec.rb
+++ b/spec/models/approval_request_spec.rb
@@ -1,7 +1,9 @@
 describe ApprovalRequest, :type => :model do
   let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
-  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
-  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
+  let(:order1) { create(:order) }
+  let(:order2) { create(:order) }
+  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order1.id) }
+  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order2.id) }
   let!(:approval_request1) { create(:approval_request, :order_item_id => order_item1.id) }
   let!(:approval_request2) { create(:approval_request, :order_item_id => order_item2.id) }
 
@@ -13,7 +15,7 @@ describe ApprovalRequest, :type => :model do
     let(:results) { ApprovalRequest.by_owner }
 
     before do
-      order_item2.update!(:owner => "not_jdoe")
+      order2.update!(:owner => "not_jdoe")
     end
 
     it "only has one result" do
@@ -21,7 +23,7 @@ describe ApprovalRequest, :type => :model do
     end
 
     it "filters by the owner" do
-      expect(results.first.owner).to eq "jdoe"
+      expect(results.first.id).to eq approval_request1.id
     end
   end
 end

--- a/spec/models/progress_message_spec.rb
+++ b/spec/models/progress_message_spec.rb
@@ -1,0 +1,27 @@
+describe ProgressMessage, :type => :model do
+  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
+  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
+  let!(:progress_message1) { create(:progress_message, :order_item_id => order_item1.id) }
+  let!(:progress_message2) { create(:progress_message, :order_item_id => order_item2.id) }
+
+  around do |example|
+    ManageIQ::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  context "by_owner" do
+    let(:results) { ProgressMessage.by_owner }
+
+    before do
+      order_item2.update!(:owner => "not_jdoe")
+    end
+
+    it "only has one result" do
+      expect(results.size).to eq 1
+    end
+
+    it "filters by the owner" do
+      expect(results.first.owner).to eq "jdoe"
+    end
+  end
+end

--- a/spec/models/progress_message_spec.rb
+++ b/spec/models/progress_message_spec.rb
@@ -1,7 +1,9 @@
 describe ProgressMessage, :type => :model do
   let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
-  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
-  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => 1) }
+  let(:order1) { create(:order) }
+  let(:order2) { create(:order) }
+  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order1.id) }
+  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order2.id) }
   let!(:progress_message1) { create(:progress_message, :order_item_id => order_item1.id) }
   let!(:progress_message2) { create(:progress_message, :order_item_id => order_item2.id) }
 
@@ -13,7 +15,7 @@ describe ProgressMessage, :type => :model do
     let(:results) { ProgressMessage.by_owner }
 
     before do
-      order_item2.update!(:owner => "not_jdoe")
+      order2.update!(:owner => "not_jdoe")
     end
 
     it "only has one result" do
@@ -21,7 +23,7 @@ describe ProgressMessage, :type => :model do
     end
 
     it "filters by the owner" do
-      expect(results.first.owner).to eq "jdoe"
+      expect(results.first.id).to eq progress_message1.id
     end
   end
 end


### PR DESCRIPTION
After discussing with Madhu, we're going back and forth on whether to have the `owner` field on the `ApprovalRequest` and `ProgressMessage` models. 

We could just use a lookup on the `order_item` for each of these, but this would allow us to sort them by the owner to a further subset of the `tenant`. 

This PR is mainly for the discussion to take place. 