### PR TITLE
Intermittent Spec failure

### DIFF
--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -1,6 +1,6 @@
 describe Portfolio do
-  let(:tenant1)           { create(:tenant) }
-  let(:tenant2)           { create(:tenant) }
+  let(:tenant1)           { create(:tenant, :external_tenant => 1) }
+  let(:tenant2)           { create(:tenant, :external_tenant => 2) }
   let(:portfolio)         { create(:portfolio, :tenant_id => tenant1.id) }
   let(:portfolio_id)      { portfolio.id }
   let(:portfolio_item)    { create(:portfolio_item, :tenant_id => tenant1.id) }


### PR DESCRIPTION
Whenever there a 2 tenants involved in a single spec the onus is
on the spec to create 2 unique external_tenant instead of relying on
the factory.

Fixes #265 