### PR TITLE
Consume task update 'running' state progress messages

### DIFF
--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -46,13 +46,19 @@ module Catalog
     def mark_item_based_on_status
       case @payload["status"]
       when "ok"
-        mark_item_finished
-        @order_item.order.finalize_order
+        case @payload["state"]
+        when "completed"
+          mark_item_finished
+          @order_item.order.finalize_order
+        when "running"
+          @order_item.update_message("info", "Order Item being processed with context: #{@payload["context"]}")
+          @order_item.save!
+        end
       when "error"
         mark_item_failed
         @order_item.order.finalize_order
       else
-        # Do nothing for now
+        # Do nothing for now, only other case is "warn"
       end
     end
 

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -2,7 +2,7 @@ describe Catalog::UpdateOrderItem do
   describe "#process" do
     let(:client) { double(:client) }
     let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client) }
-    let(:payload) { {"task_id" => "123", "status" => status} }
+    let(:payload) { {"task_id" => "123", "status" => status, "state" => state, "context" => "payloadcontext"} }
     let!(:item) do
       ManageIQ::API::Common::Request.with_request(default_request) do
         create(:order_item,
@@ -17,6 +17,7 @@ describe Catalog::UpdateOrderItem do
     context "when the order item is not findable" do
       let(:topology_task_ref) { "0" }
       let(:status) { "ok" }
+      let(:state) { "bar" }
 
       it "raises an error" do
         expect { subject.process }.to raise_error("Could not find an OrderItem with topology_task_ref: 123")
@@ -43,70 +44,88 @@ describe Catalog::UpdateOrderItem do
             to_return(:status => 200, :body => task.to_json, :headers => {})
         end
 
-        context "when the service instance can be found" do
-          before do
-            stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
-              with(:headers => {'Content-Type'=>'application/json'}).
-              to_return(:status => 200, :body => service_instance.to_json, :headers => {})
+        context "when the state is completed" do
+          let(:state) { "completed" }
+
+          context "when the service instance can be found" do
+            before do
+              stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
+                with(:headers => {'Content-Type'=>'application/json'}).
+                to_return(:status => 200, :body => service_instance.to_json, :headers => {})
+            end
+
+            it "creates a progress message about the payload" do
+              subject.process
+              latest_progress_message = ProgressMessage.second_to_last
+              expect(latest_progress_message.level).to eq("info")
+              expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
+            end
+
+            it "updates the completed at time" do
+              fake_now = DateTime.now.iso8601
+              allow(DateTime).to receive(:now).and_return(fake_now)
+              subject.process
+              item.reload
+              expect(item.completed_at).to eq(fake_now)
+            end
+
+            it "updates the order item to be completed" do
+              subject.process
+              item.reload
+              expect(item.state).to eq("Completed")
+            end
+
+            it "creates a progress message about the completion" do
+              subject.process
+              latest_progress_message = ProgressMessage.last
+              expect(latest_progress_message.level).to eq("info")
+              expect(latest_progress_message.message).to eq("Order Item Complete")
+            end
+
+            it "updates the order item with the external url" do
+              subject.process
+              item.reload
+              expect(item.external_url).to eq("external url")
+            end
+
+            it "finalizes the order" do
+              expect(order.state).to_not eq("Completed")
+              subject.process
+              order.reload
+              expect(order.state).to eq("Completed")
+            end
           end
 
-          it "creates a progress message about the payload" do
-            subject.process
-            latest_progress_message = ProgressMessage.second_to_last
-            expect(latest_progress_message.level).to eq("info")
-            expect(latest_progress_message.message).to eq("Task update message received with payload: #{payload}")
-          end
+          context "when the service instance does not have an external url" do
+            before do
+              stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
+                with(:headers => {'Content-Type'=>'application/json'}).
+                to_return(:status => 200, :body => "".to_json, :headers => {})
+            end
 
-          it "updates the completed at time" do
-            fake_now = DateTime.now.iso8601
-            allow(DateTime).to receive(:now).and_return(fake_now)
-            subject.process
-            item.reload
-            expect(item.completed_at).to eq(fake_now)
-          end
-
-          it "updates the order item to be completed" do
-            subject.process
-            item.reload
-            expect(item.state).to eq("Completed")
-          end
-
-          it "creates a progress message about the completion" do
-            subject.process
-            latest_progress_message = ProgressMessage.last
-            expect(latest_progress_message.level).to eq("info")
-            expect(latest_progress_message.message).to eq("Order Item Complete")
-          end
-
-          it "updates the order item with the external url" do
-            subject.process
-            item.reload
-            expect(item.external_url).to eq("external url")
-          end
-
-          it "finalizes the order" do
-            expect(order.state).to_not eq("Completed")
-            subject.process
-            order.reload
-            expect(order.state).to eq("Completed")
+            it "raises an error" do
+              expect { subject.process }.to raise_error("Could not find an external url on service instance (id: 321) attached to task_id: 123")
+            end
           end
         end
 
-        context "when the service instance does not have an external url" do
-          before do
-            stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
-              with(:headers => {'Content-Type'=>'application/json'}).
-              to_return(:status => 200, :body => "".to_json, :headers => {})
-          end
+        context "when the state is running" do
+          let(:state) { "running" }
 
-          it "raises an error" do
-            expect { subject.process }.to raise_error("Could not find an external url on service instance (id: 321) attached to task_id: 123")
+          it "creates multiple progress messages" do
+            subject.process
+            payload_progress_message, context_progress_message = ProgressMessage.last(2)
+            expect(payload_progress_message.level).to eq("info")
+            expect(context_progress_message.level).to eq("info")
+            expect(payload_progress_message.message).to eq("Task update message received with payload: #{payload}")
+            expect(context_progress_message.message).to eq("Order Item being processed with context: payloadcontext")
           end
         end
       end
 
       context "when the status of the task is error" do
         let(:status) { "error" }
+        let(:state) { "bar" }
 
         it "creates a progress message about the payload" do
           subject.process
@@ -146,6 +165,7 @@ describe Catalog::UpdateOrderItem do
 
       context "when the status of the task is anything else" do
         let(:status) { "foo" }
+        let(:state) { "bar" }
 
         it "creates a progress message about the payload" do
           subject.process

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -39,9 +39,9 @@ describe Catalog::UpdateOrderItem do
         let(:service_instance) { TopologicalInventoryApiClient::ServiceInstance.new(:external_url => "external url") }
 
         before do
-          stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/tasks/123").
-            with(:headers => {'Accept'=>'application/json', 'Content-Type'=>'application/json'}).
-            to_return(:status => 200, :body => task.to_json, :headers => {})
+          stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/tasks/123")
+            .with(:headers => {'Accept' => 'application/json', 'Content-Type' => 'application/json'})
+            .to_return(:status => 200, :body => task.to_json, :headers => {})
         end
 
         context "when the state is completed" do
@@ -49,9 +49,9 @@ describe Catalog::UpdateOrderItem do
 
           context "when the service instance can be found" do
             before do
-              stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
-                with(:headers => {'Content-Type'=>'application/json'}).
-                to_return(:status => 200, :body => service_instance.to_json, :headers => {})
+              stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321")
+                .with(:headers => {'Content-Type'=>'application/json'})
+                .to_return(:status => 200, :body => service_instance.to_json, :headers => {})
             end
 
             it "creates a progress message about the payload" do
@@ -62,7 +62,7 @@ describe Catalog::UpdateOrderItem do
             end
 
             it "updates the completed at time" do
-              fake_now = DateTime.now.iso8601
+              fake_now = Time.now.iso8601
               allow(DateTime).to receive(:now).and_return(fake_now)
               subject.process
               item.reload
@@ -98,9 +98,9 @@ describe Catalog::UpdateOrderItem do
 
           context "when the service instance does not have an external url" do
             before do
-              stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321").
-                with(:headers => {'Content-Type'=>'application/json'}).
-                to_return(:status => 200, :body => "".to_json, :headers => {})
+              stub_request(:get, "http://localhost:3000/api/topological-inventory/v0.1/service_instances/321")
+                .with(:headers => {'Content-Type'=>'application/json'})
+                .to_return(:status => 200, :body => "".to_json, :headers => {})
             end
 
             it "raises an error" do
@@ -135,7 +135,7 @@ describe Catalog::UpdateOrderItem do
         end
 
         it "updates the completed at time" do
-          fake_now = DateTime.now.iso8601
+          fake_now = Time.now.iso8601
           allow(DateTime).to receive(:now).and_return(fake_now)
           subject.process
           item.reload


### PR DESCRIPTION
After topology is updated to include task updates for various progress messages [via this PR](https://github.com/ManageIQ/topological_inventory-openshift/pull/78), this change will handle the messages and update the order item with progress messages.

Edit: Though, this PR should be merged first, because if we merge the topology one first, the status "ok" will be sent over with the state "running", but the current code only checks the status, so it will mark things that are "running" as completed.

@mkanoor, @syncrou Please Review, let me know if you guys think the `@order_item.state` 'Processing' is ok, and if the update messages are sufficient or if you want some other state/language.