### PR TITLE
Remove potential duplication from sequence

### DIFF
--- a/spec/factories/tenants.rb
+++ b/spec/factories/tenants.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tenant do
-    sequence(:external_tenant) { |n| n + rand(1000) }
+    sequence(:external_tenant)
 
     trait :with_external_tenant do
       external_tenant { "0369233" }


### PR DESCRIPTION
This code was not right from the beginning. It should have
been something like `{ |n| "#{n}12345" }`
adding in the bare `rand(1000)` actually guaranteed we would have duplicates.

This should solve the issue of the randomly failing test.