### PR TITLE
Change level of failed order item message from info to error

### DIFF
--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -70,7 +70,7 @@ module Catalog
     def mark_item_failed
       @order_item.completed_at = DateTime.now
       @order_item.state = "Failed"
-      @order_item.update_message("info", "Order Item Failed")
+      @order_item.update_message("error", "Order Item Failed")
 
       Rails.logger.info("Updating OrderItem: #{@order_item.id} with 'Failed' state")
       @order_item.save!

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -132,7 +132,7 @@ describe Catalog::UpdateOrderItem do
         it "creates a progress message about the failure" do
           subject.process
           latest_progress_message = ProgressMessage.last
-          expect(latest_progress_message.level).to eq("info")
+          expect(latest_progress_message.level).to eq("error")
           expect(latest_progress_message.message).to eq("Order Item Failed")
         end
 


### PR DESCRIPTION
Pretty simple change, an oversight on my part when creating the progress message for the failed state of an order item.