### PR TITLE
Add Denied state to OrderItem OpenAPI JSON

### DIFF
--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1413,7 +1413,8 @@
               "Approval Pending",
               "Ordered",
               "Failed",
-              "Completed"
+              "Completed",
+              "Denied"
             ],
             "title": "State",
             "description": "Current state of this order item.",


### PR DESCRIPTION
Forgot to add "Denied" to the state enum for Order and OrderItem.