### PR TITLE
Spec tenancy cleanup

### DIFF
--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ApplicationController, :type => :request do
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let(:portfolio)         { Portfolio.create!(:name => 'tenant_portfolio', :description => 'tenant desc', :tenant_id => tenant.id, :owner => 'wilma') }
   let(:portfolio_id)      { portfolio.id }
 

--- a/spec/factories/tenants.rb
+++ b/spec/factories/tenants.rb
@@ -1,9 +1,5 @@
 FactoryBot.define do
   factory :tenant do
-    sequence(:external_tenant)
-
-    trait :with_external_tenant do
-      external_tenant { "0369233" }
-    end
+    external_tenant { UserHeaderSpecHelper::DEFAULT_USER['identity']['account_number'] }
   end
 end

--- a/spec/lib/open_api/serializer_spec.rb
+++ b/spec/lib/open_api/serializer_spec.rb
@@ -1,5 +1,4 @@
 describe OpenApi::Serializer do
-
   let(:tenant) { create(:tenant) }
   let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => create(:portfolio, :tenant_id => tenant.id)) }
 

--- a/spec/lib/open_api/serializer_spec.rb
+++ b/spec/lib/open_api/serializer_spec.rb
@@ -1,5 +1,7 @@
 describe OpenApi::Serializer do
-  let(:portfolio_item) { create(:portfolio_item, :portfolio => create(:portfolio)) }
+
+  let(:tenant) { create(:tenant) }
+  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => create(:portfolio, :tenant_id => tenant.id)) }
 
   it "converts id columns to strings" do
     expect(portfolio_item.as_json).to include(

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,5 +1,5 @@
 describe OrderItem do
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
   let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => 123, :tenant_id => tenant.id) }
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,5 +1,5 @@
 describe Order do
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:order1) { create(:order, :tenant_id => tenant.id) }
   let!(:order2) { create(:order, :tenant_id => tenant.id) }
   let!(:order3) { create(:order, :tenant_id => tenant.id, :owner => 'barney') }

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -1,5 +1,7 @@
 describe PortfolioItem do
-  let(:item) { PortfolioItem.new }
+  let(:tenant) { create(:tenant) }
+  let(:item) { PortfolioItem.new(:tenant_id => tenant.id) }
+  
   let(:service_offering_ref) { "1" }
   let(:owner) { 'wilma' }
 
@@ -36,13 +38,14 @@ describe PortfolioItem do
   context "#item_workflow_ref" do
     let(:item_workflow_ref) { "portfolio_item_workflow_ref" }
     let(:portfolio_workflow_ref) { "portfolio_workflow_ref" }
-    let(:portfolio) { create(:portfolio, :workflow_ref => portfolio_workflow_ref) }
+    let(:portfolio) { create(:portfolio, :workflow_ref => portfolio_workflow_ref, :tenant_id => tenant.id) }
 
     let(:portfolio_item) do
       create(:portfolio_item,
              :service_offering_ref => "123",
              :portfolio_id         => portfolio.id,
-             :workflow_ref         => item_workflow_ref)
+             :workflow_ref         => item_workflow_ref,
+             :tenant_id            => tenant.id)
     end
 
     let(:ref) { portfolio_item.send(:item_workflow_ref) }

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -1,7 +1,7 @@
 describe PortfolioItem do
   let(:tenant) { create(:tenant) }
   let(:item) { PortfolioItem.new(:tenant_id => tenant.id) }
-  
+
   let(:service_offering_ref) { "1" }
   let(:owner) { 'wilma' }
 

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -1,6 +1,6 @@
 describe Portfolio do
-  let(:tenant1)           { create(:tenant) }
-  let(:tenant2)           { create(:tenant) }
+  let(:tenant1)           { create(:tenant, :external_tenant => "1") }
+  let(:tenant2)           { create(:tenant, :external_tenant => "2") }
   let(:portfolio)         { create(:portfolio, :tenant_id => tenant1.id) }
   let(:portfolio_id)      { portfolio.id }
   let(:portfolio_item)    { create(:portfolio_item, :tenant_id => tenant1.id) }

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -6,7 +6,7 @@ describe "IconsRequests", :type => :request do
       .as_stubbed_const(:transfer_nested_constants => true)
   end
 
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let(:portfolio_item) do
     create(:portfolio_item, :service_offering_icon_ref => icon_id,
                             :tenant_id                 => tenant.id)

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -5,7 +5,7 @@ describe "OrderItemsRequests", :type => :request do
     end
   end
 
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:order_1) { create(:order, :tenant_id => tenant.id) }
   let!(:order_2) { create(:order, :tenant_id => tenant.id) }
   let!(:order_item_1) { create(:order_item, :order_id => order_1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -4,7 +4,7 @@ describe "OrderRequests", :type => :request do
       example.call
     end
   end
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:order) { create(:order, :tenant_id => tenant.id) }
   let!(:order2) { create(:order, :tenant_id => tenant.id) }
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -7,7 +7,7 @@ describe "PortfolioItemRequests", :type => :request do
 
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
   let(:portfolio_item) do
     create(:portfolio_item, :service_offering_ref        => service_offering_ref,

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -1,5 +1,5 @@
 describe 'Portfolios Read Access RBAC API' do
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :id_list => id_list) }

--- a/spec/requests/portfolios_rbac_spec.rb
+++ b/spec/requests/portfolios_rbac_spec.rb
@@ -1,5 +1,5 @@
 describe 'Portfolios RBAC API' do
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :id_list => [portfolio1.id.to_s]) }

--- a/spec/requests/portfolios_rbac_write_access_spec.rb
+++ b/spec/requests/portfolios_rbac_write_access_spec.rb
@@ -1,5 +1,5 @@
 describe 'Portfolios Write Access RBAC API' do
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :id_list => id_list) }

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -5,7 +5,7 @@ describe 'Portfolios API' do
     end
   end
 
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let!(:portfolio)            { create(:portfolio, :tenant_id => tenant.id) }
   let!(:portfolio_item)       { create(:portfolio_item, :tenant_id => tenant.id) }
   let!(:portfolio_items)      { portfolio.portfolio_items << portfolio_item }

--- a/spec/requests/progress_message_spec.rb
+++ b/spec/requests/progress_message_spec.rb
@@ -5,7 +5,7 @@ describe "ProgressMessageRequests", :type => :request do
     end
   end
 
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -1,7 +1,7 @@
 describe Catalog::CreateApprovalRequest do
   let(:create_approval_request) { described_class.new(order.id) }
 
-  let(:tenant) { create(:tenant, :external_tenant => default_user_hash['identity']['account_number']) }
+  let(:tenant) { create(:tenant) }
   let(:workflow_ref) { "1" }
   let!(:order) { create(:order, :tenant_id => tenant.id) }
   let!(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }


### PR DESCRIPTION
1. Make it easier to create a tenant, that by default uses the standard account number.
2. Couple of specs were creating PortfolioItem and Portfolio in different tenants unintentionally