### PR TITLE
Change filter "operator" to proper accessor name "operation"

### DIFF
--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -45,7 +45,7 @@ module RBAC
       @ids ||= @acl.each_with_object([]) do |item, ids|
         item.resource_definitions.each do |rd|
           next unless rd.attribute_filter.key == 'id'
-          next unless rd.attribute_filter.operator == 'equal'
+          next unless rd.attribute_filter.operation == 'equal'
           ids << rd.attribute_filter.value
         end
       end
@@ -55,7 +55,7 @@ module RBAC
       @acl.any? do |item|
         item.resource_definitions.any? do |rd|
           rd.attribute_filter.key == 'owner' &&
-            rd.attribute_filter.operator == 'equal' &&
+            rd.attribute_filter.operation == 'equal' &&
             rd.attribute_filter.value == '{{username}}'
         end
       end

--- a/lib/rbac/acls.rb
+++ b/lib/rbac/acls.rb
@@ -51,7 +51,7 @@ module RBAC
 
     def matches?(access, resource_id, permission)
       access.permission == permission &&
-        access.resource_definitions.any? { |rdf| rdf.attribute_filter.key == 'id' && rdf.attribute_filter.operator == 'equal' && rdf.attribute_filter.value == resource_id }
+        access.resource_definitions.any? { |rdf| rdf.attribute_filter.key == 'id' && rdf.attribute_filter.operation == 'equal' && rdf.attribute_filter.value == resource_id }
     end
 
     def find_matching(acls, resource_id, permission)

--- a/spec/lib/rbac/access_spec.rb
+++ b/spec/lib/rbac/access_spec.rb
@@ -2,10 +2,10 @@ describe RBAC::Access do
   let(:app_name) { 'catalog' }
   let(:resource) { "portfolio" }
   let(:verb) { "read" }
-  let(:attr_filter1) { double(:key => 'id', :operator => 'equal', :value => '25') }
-  let(:attr_filter2) { double(:key => 'id', :operator => 'equal', :value => '26') }
-  let(:attr_filter3) { double(:key => 'id', :operator => 'equal', :value => '27') }
-  let(:attr_filter4) { double(:key => 'id', :operator => 'equal', :value => '*') }
+  let(:attr_filter1) { double(:key => 'id', :operation => 'equal', :value => '25') }
+  let(:attr_filter2) { double(:key => 'id', :operation => 'equal', :value => '26') }
+  let(:attr_filter3) { double(:key => 'id', :operation => 'equal', :value => '27') }
+  let(:attr_filter4) { double(:key => 'id', :operation => 'equal', :value => '*') }
   let(:resource_def1) { double(:attribute_filter => attr_filter1) }
   let(:resource_def2) { double(:attribute_filter => attr_filter2) }
   let(:resource_def3) { double(:attribute_filter => attr_filter3) }

--- a/spec/support/rbac_shared_contexts.rb
+++ b/spec/support/rbac_shared_contexts.rb
@@ -16,9 +16,9 @@ RSpec.shared_context "rbac_objects" do
   let(:groups) { [group1, group2, group3] }
   let(:roles) { [role1] }
   let(:policies) { [double(:group => group1, :roles => roles)] }
-  let(:resource_def1) { double(:attribute_filter => double(:key => 'id', :operator => 'equal', :value => resource_id1)) }
-  let(:resource_def2) { double(:attribute_filter => double(:key => 'id', :operator => 'equal', :value => resource_id2)) }
-  let(:resource_def3) { double(:attribute_filter => double(:key => 'id', :operator => 'equal', :value => resource_id3)) }
+  let(:resource_def1) { double(:attribute_filter => double(:key => 'id', :operation => 'equal', :value => resource_id1)) }
+  let(:resource_def2) { double(:attribute_filter => double(:key => 'id', :operation => 'equal', :value => resource_id2)) }
+  let(:resource_def3) { double(:attribute_filter => double(:key => 'id', :operation => 'equal', :value => resource_id3)) }
   let(:access1) { double(:permission => "#{app_name}:#{resource}:read", :resource_definitions => [resource_def1]) }
   let(:access2) { double(:permission => "#{app_name}:#{resource}:write", :resource_definitions => [resource_def2]) }
   let(:access3) { double(:permission => "#{app_name}:#{resource}:order", :resource_definitions => []) }
@@ -27,8 +27,8 @@ RSpec.shared_context "rbac_objects" do
   let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
   let(:current_user) { '{{username}}' }
   let(:id_value) { '*' }
-  let(:owner_resource_def) { double(:attribute_filter => double(:key => 'owner', :operator => 'equal', :value => current_user)) }
-  let(:id_resource_def) { double(:attribute_filter => double(:key => 'id', :operator => 'equal', :value => id_value)) }
+  let(:owner_resource_def) { double(:attribute_filter => double(:key => 'owner', :operation => 'equal', :value => current_user)) }
+  let(:id_resource_def) { double(:attribute_filter => double(:key => 'id', :operation => 'equal', :value => id_value)) }
   let(:owner_resource) { 'orders' }
   let(:owner_permission) { "#{app_name}:#{owner_resource}:read" }
   let(:owner_access) { double(:permission => owner_permission, :resource_definitions => [owner_resource_def]) }


### PR DESCRIPTION
As defined in the RBAC service:
https://github.com/RedHatInsights/insights-rbac-api-client-ruby/blame/master/lib/rbac-api-client/models/resource_definition_filter.rb#L19

Fixes https://github.com/ManageIQ/catalog-api/issues/275

Fix catalog-api returning 500 errors.

@Hyperkid123 Thanks for tracking this down!