### PR TITLE
Rescue from ParamterMissing with 422 error instead of 404

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::API
   rescue_from Catalog::TopologyError, :with => :topology_service_error
   rescue_from Catalog::NotAuthorized, :with => :forbidden_error
   rescue_from ManageIQ::API::Common::IdentityError, :with => :unauthorized_error
+  rescue_from ActionController::ParameterMissing, :with => :unprocessable_entity_error
 
   around_action :with_current_request
 

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -16,4 +16,9 @@ module Response
     Rails.logger.error("Unauthorized error: #{err.message}")
     render :json => {:message => "Unauthorized"}, :status => :unauthorized
   end
+
+  def unprocessable_entity_error(err)
+    Rails.logger.error("Unprocessable Entity error: #{err.message}")
+    render :json => {:message => "Unprocessable Entity"}, :status => :unprocessable_entity
+  end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-345

When cleaning up the controller, a `rescue_from` was added for MIQ::IdentityError, but not for the ParameterMissing exception, resulting in a 404 instead of a 422 like we wanted. This fixes that by rescuing from ParamterMissing and returning a 422 as desired.