### PR TITLE
Throw an error when submitting an Order with no workflow_ref

### DIFF
--- a/app/controllers/api/v1x0/orders_controller.rb
+++ b/app/controllers/api/v1x0/orders_controller.rb
@@ -14,6 +14,8 @@ module Api
       def submit_order
         approval = Catalog::CreateApprovalRequest.new(params.require(:order_id))
         render :json => approval.process.order
+      rescue Catalog::ApprovalError => e
+        render :json => { :errors => e.message }, :status => :internal_server_error
       end
     end
   end

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -44,7 +44,13 @@ module Catalog
     end
 
     def workflows(portfolio_item)
-      portfolio_item.resolved_workflow_refs
+      workflows = portfolio_item.resolved_workflow_refs
+      case workflows
+      when :empty?.to_proc
+        raise Catalog::ApprovalError, "No Approval workflows assigned"
+      when :present?.to_proc
+        workflows
+      end
     end
 
     def create_approval_request(req)

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -52,6 +52,18 @@ describe Catalog::CreateApprovalRequest do
         expect { request }.to raise_exception(Catalog::ApprovalError)
       end
     end
+
+    context "when the item has no workflow_ref" do
+      before do
+        allow(approval).to receive(:call).and_yield(api_instance)
+        allow(api_instance).to receive(:create_request).and_return(approval_response)
+        portfolio_item.update!(:workflow_ref => nil)
+      end
+
+      it "throws an exception" do
+        expect { request }.to raise_exception(Catalog::ApprovalError)
+      end
+    end
   end
 
   context "private methods" do
@@ -87,6 +99,11 @@ describe Catalog::CreateApprovalRequest do
       it "returns the workflow from portfolio_item" do
         workflows = create_approval_request.send(:workflows, portfolio_item)
         expect(workflows.first).to eq portfolio_item.workflow_ref
+      end
+
+      it "blows up when there is no workflow ref" do
+        portfolio_item.workflow_ref = nil
+        expect { create_approval_request.send(:workflows, portfolio_item) }.to raise_exception(Catalog::ApprovalError)
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-250

Currently there is no logic when an Order has _no_ workflows assigned to the portfolio items or portfolios, when an order like this is submitted it gets marked as "Approval Pending" forever and just sits in limbo. This PR adds logic to error out before any of that happens - throwing a 422 on submit. 