### PR TITLE
Add requirement on service_offering_ref to throw 422 instead of 404

### DIFF
--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -39,7 +39,7 @@ module Api
       private
 
       def portfolio_item_params
-        params.permit(:service_offering_ref, :workflow_ref)
+        params.permit(:service_offering_ref, :workflow_ref).require(:service_offering_ref)
       end
 
       def portfolio_item_patch_params


### PR DESCRIPTION
This should fix the 422/404 on the `create_portfolio_item`call.