### PR TITLE
Store & expose the x-rh-insights-request-id from order_item

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -15,8 +15,8 @@ class OrderItem < ApplicationRecord
   has_many :approval_requests, :dependent => :destroy
   before_create :set_defaults
 
-  AS_JSON_ATTRIBUTES = %w(id order_id service_plan_ref portfolio_item_id state service_parameters external_url
-                          provider_control_parameters external_ref created_at ordered_at completed_at updated_at).freeze
+  AS_JSON_ATTRIBUTES = %w[id order_id service_plan_ref portfolio_item_id state service_parameters external_url
+                          provider_control_parameters external_ref insights_request_id created_at ordered_at completed_at updated_at].freeze
 
   def as_json(_options = {})
     super.slice(*AS_JSON_ATTRIBUTES)
@@ -24,7 +24,11 @@ class OrderItem < ApplicationRecord
 
   def set_defaults
     self.state = "Created"
-    self.context = ManageIQ::API::Common::Request.current.to_h
+
+    if ManageIQ::API::Common::Request.current.present?
+      self.context = ManageIQ::API::Common::Request.current.to_h
+      self.insights_request_id = ManageIQ::API::Common::Request.current.request_id
+    end
   end
 
   def update_message(level, message)

--- a/db/migrate/20190501163638_add_insights_request_id_to_order_item.rb
+++ b/db/migrate/20190501163638_add_insights_request_id_to_order_item.rb
@@ -1,0 +1,5 @@
+class AddInsightsRequestIdToOrderItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :order_items, :insights_request_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_09_143525) do
+ActiveRecord::Schema.define(version: 2019_05_01_163638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2019_04_09_143525) do
     t.jsonb "context"
     t.string "owner"
     t.string "external_url"
+    t.string "insights_request_id"
     t.index ["tenant_id"], name: "index_order_items_on_tenant_id"
   end
 

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1454,6 +1454,13 @@
             "type": "string",
             "title": "External url",
             "description": "The external url of the service instance used with relation to this order item"
+          },
+          "insights_request_id":{
+            "type": "string",
+            "title": "Insights Request ID ",
+            "example": "364498f142194beba576833d7303abe5",
+            "description": "The insights request id can be used to collect log data for this order item as its processed by the system",
+            "readOnly": true
           }
         }
       },

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     service_plan_ref { "something" }
     count { 1 }
     owner { default_username }
+    insights_request_id { "insights-request-id" }
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-335

This PR adds functionality to store the `x-rh-insights-request-id` header on `OrderItem` and exposes it through the API.

I reorganized the `spec/requests/order_item_spec.rb` as well to use contexts for each operation.