### PR TITLE
Force a require lookup first

### DIFF
--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -39,7 +39,8 @@ module Api
       private
 
       def portfolio_item_params
-        params.permit(:service_offering_ref, :workflow_ref).require(:service_offering_ref)
+        params.require(:service_offering_ref)
+        params.permit(:service_offering_ref, :workflow_ref)
       end
 
       def portfolio_item_patch_params


### PR DESCRIPTION
Strong params do not allow for chaining the .require method
this fix forces a check on the required parameter first and raises a 422
if it doesn't exist. If it does exist than the permit line is called