### PR TITLE
Refactor the way the Order state gets handled throughout the Approval Process

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,19 +19,24 @@ class Order < ApplicationRecord
   end
 
   def transition_state
+    update!(:state => determine_order_state)
+  end
+
+  private
+
+  def determine_order_state
     item_states = order_items.collect(&:state)
 
     if item_states.include?('Failed')
-      self.state = "Failed"
+      'Failed'
     elsif item_states.include?('Denied')
-      self.state = "Denied"
+      'Denied'
     elsif item_states.all? { |state| state == "Approved" }
-      self.state = 'Approved'
+      'Approved'
     elsif item_states.all? { |state| state == "Completed" }
-      self.state = 'Completed'
+      'Completed'
     else
-      self.state = 'Ordered'
+      'Ordered'
     end
-    save!
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
 
   has_many :order_items
 
-  after_initialize :set_defaults, unless: :persisted?
+  before_create :set_defaults
 
   AS_JSON_ATTRIBUTES = %w[id state owner created_at ordered_at completed_at].freeze
 
@@ -18,11 +18,16 @@ class Order < ApplicationRecord
     self.state = "Created"
   end
 
-  def finalize_order
+  def transition_state
     item_states = order_items.collect(&:state)
+
     if item_states.include?('Failed')
       self.state = "Failed"
-    elsif item_states.include?('Completed') && item_states.count == order_items.count
+    elsif item_states.include?('Denied')
+      self.state = "Denied"
+    elsif item_states.all? { |state| state == "Approved" }
+      self.state = 'Approved'
+    elsif item_states.all? { |state| state == "Completed" }
       self.state = 'Completed'
     else
       self.state = 'Ordered'

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -17,26 +17,4 @@ class Order < ApplicationRecord
   def set_defaults
     self.state = "Created"
   end
-
-  def transition_state
-    update!(:state => determine_order_state)
-  end
-
-  private
-
-  def determine_order_state
-    item_states = order_items.collect(&:state)
-
-    if item_states.include?('Failed')
-      'Failed'
-    elsif item_states.include?('Denied')
-      'Denied'
-    elsif item_states.all? { |state| state == "Approved" }
-      'Approved'
-    elsif item_states.all? { |state| state == "Completed" }
-      'Completed'
-    else
-      'Ordered'
-    end
-  end
 end

--- a/app/services/catalog/approval_transition.rb
+++ b/app/services/catalog/approval_transition.rb
@@ -27,7 +27,7 @@ module Catalog
         mark_denied
       else
         @state = "Pending"
-        @order_item.order.transition_state
+        Catalog::OrderStateTransition.new(@order_item.order_id).process
       end
     end
 
@@ -47,7 +47,7 @@ module Catalog
 
     def finalize_order
       @order_item.update(:state => @state)
-      @order_item.order.transition_state
+      Catalog::OrderStateTransition.new(@order_item.order_id).process
     end
 
     def approved?

--- a/app/services/catalog/approval_transition.rb
+++ b/app/services/catalog/approval_transition.rb
@@ -20,13 +20,13 @@ module Catalog
 
     def state_transitions
       if approved?
-        @state = "approved"
+        @state = "Approved"
         submit_order
       elsif denied?
-        @state = "denied"
+        @state = "Denied"
         mark_denied
       else
-        @state = "pending"
+        @state = "Pending"
         @order_item.order.transition_state
       end
     end
@@ -34,19 +34,19 @@ module Catalog
     def submit_order
       @order_item.update_message("info", "Submitting Order #{@order_item.order_id} for provisioning ")
       Catalog::SubmitOrder.new(@order_item.order_id).process
-      finalize_order("Approved")
+      finalize_order
     rescue Catalog::TopologyError => e
       Rails.logger.error("Error Submitting Order #{@order_item.order_id}, #{e.message}")
       @order_item.update_message("error", "Error Submitting Order #{@order_item.order_id}, #{e.message}")
     end
 
     def mark_denied
-      finalize_order("Denied")
+      finalize_order
       @order_item.update_message("info", "Order #{@order_item.order_id} has been denied")
     end
 
-    def finalize_order(state)
-      @order_item.update(:state => state)
+    def finalize_order
+      @order_item.update(:state => @state)
       @order_item.order.transition_state
     end
 

--- a/app/services/catalog/order_state_transition.rb
+++ b/app/services/catalog/order_state_transition.rb
@@ -1,0 +1,30 @@
+module Catalog
+  class OrderStateTransition
+    attr_reader :state
+
+    def initialize(order_id)
+      @order = Order.find(order_id)
+    end
+
+    def process
+      @state = determine_order_state
+      @order.update!(:state => @state)
+
+      self
+    end
+
+    private
+
+    def determine_order_state
+      item_states = @order.order_items.collect(&:state)
+
+      if item_states.include?('Failed') || item_states.include?('Denied')
+        'Failed'
+      elsif item_states.all? { |state| state == "Completed" }
+        'Completed'
+      else
+        'Ordered'
+      end
+    end
+  end
+end

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -49,14 +49,14 @@ module Catalog
         case @payload["state"]
         when "completed"
           mark_item_finished
-          @order_item.order.transition_state
+          Catalog::OrderStateTransition.new(@order_item.order_id).process
         when "running"
           @order_item.update_message("info", "Order Item being processed with context: #{@payload["context"]}")
           @order_item.save!
         end
       when "error"
         mark_item_failed
-        @order_item.order.transition_state
+        Catalog::OrderStateTransition.new(@order_item.order_id).process
       else
         # Do nothing for now, only other case is "warn"
       end

--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -49,14 +49,14 @@ module Catalog
         case @payload["state"]
         when "completed"
           mark_item_finished
-          @order_item.order.finalize_order
+          @order_item.order.transition_state
         when "running"
           @order_item.update_message("info", "Order Item being processed with context: #{@payload["context"]}")
           @order_item.save!
         end
       when "error"
         mark_item_failed
-        @order_item.order.finalize_order
+        @order_item.order.transition_state
       else
         # Do nothing for now, only other case is "warn"
       end

--- a/lib/approval_request_listener.rb
+++ b/lib/approval_request_listener.rb
@@ -40,12 +40,12 @@ class ApprovalRequestListener
     approval.order_item.update_message("info", "Approval #{approval.id} message: #{topic.message} decision:  #{topic.payload['decision']}")
 
     if topic.message == EVENT_REQUEST_FINISHED
-      Rails.logger.info("Starting update_and_log_state for Approval ID: #{approval.id} with payload: #{topic.payload}")
+      Rails.logger.debug("Starting update_and_log_state for Approval ID: #{approval.id} with payload: #{topic.payload}")
       update_and_log_state(approval, topic)
-      Rails.logger.info("Finished update_and_log_state for Approval ID: #{approval.id} with payload: #{topic.payload}")
-      Rails.logger.info("Staring Catalog::ApprovalTransition for order_item_id: #{approval.order_item_id}")
+      Rails.logger.debug("Finished update_and_log_state for Approval ID: #{approval.id} with payload: #{topic.payload}")
+      Rails.logger.debug("Staring Catalog::ApprovalTransition for order_item_id: #{approval.order_item_id}")
       Catalog::ApprovalTransition.new(approval.order_item_id).process
-      Rails.logger.info("Finished Catalog::ApprovalTransition for order_item_id: #{approval.order_item_id}")
+      Rails.logger.debug("Finished Catalog::ApprovalTransition for order_item_id: #{approval.order_item_id}")
     end
   rescue ActiveRecord::RecordNotFound
     Rails.logger.error("Could not find Approval Request with payload of #{topic.payload}")

--- a/lib/approval_request_listener.rb
+++ b/lib/approval_request_listener.rb
@@ -43,9 +43,9 @@ class ApprovalRequestListener
       Rails.logger.info("Starting update_and_log_state for Approval ID: #{approval.id} with payload: #{topic.payload}")
       update_and_log_state(approval, topic)
       Rails.logger.info("Finished update_and_log_state for Approval ID: #{approval.id} with payload: #{topic.payload}")
-      Rails.logger.info("Staring Catalog::OrderItemTransition for order_item_id: #{approval.order_item_id}")
-      Catalog::OrderItemTransition.new(approval.order_item_id).process
-      Rails.logger.info("Finished Catalog::OrderItemTransition for order_item_id: #{approval.order_item_id}")
+      Rails.logger.info("Staring Catalog::ApprovalTransition for order_item_id: #{approval.order_item_id}")
+      Catalog::ApprovalTransition.new(approval.order_item_id).process
+      Rails.logger.info("Finished Catalog::ApprovalTransition for order_item_id: #{approval.order_item_id}")
     end
   rescue ActiveRecord::RecordNotFound
     Rails.logger.error("Could not find Approval Request with payload of #{topic.payload}")

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1340,9 +1340,7 @@
               "Approval Pending",
               "Ordered",
               "Failed",
-              "Completed",
-              "Approved",
-              "Denied"
+              "Completed"
             ],
             "title": "State",
             "description": "Current State of the order."

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1340,7 +1340,9 @@
               "Approval Pending",
               "Ordered",
               "Failed",
-              "Completed"
+              "Completed",
+              "Approved",
+              "Denied"
             ],
             "title": "State",
             "description": "Current State of the order."
@@ -1414,6 +1416,7 @@
               "Ordered",
               "Failed",
               "Completed",
+              "Approved",
               "Denied"
             ],
             "title": "State",

--- a/spec/lib/approval_request_listener_spec.rb
+++ b/spec/lib/approval_request_listener_spec.rb
@@ -6,8 +6,8 @@ describe ApprovalRequestListener do
   let(:payload)              { { "request_id" => request_id, "decision" => decision, "reason" => reason } }
   let(:request_id)           { "1" }
 
-  let(:transition_class) { class_double(Catalog::OrderItemTransition).as_stubbed_const(:transfer_nested_constants => true) }
-  let(:transition_instance) { instance_double(Catalog::OrderItemTransition) }
+  let(:transition_class) { class_double(Catalog::ApprovalTransition).as_stubbed_const(:transfer_nested_constants => true) }
+  let(:transition_instance) { instance_double(Catalog::ApprovalTransition) }
 
   describe "#subscribe_to_approval_updates" do
     let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, event, payload, nil, client) }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -4,88 +4,11 @@ describe Order do
   let!(:order2) { create(:order, :tenant_id => tenant.id) }
   let!(:order3) { create(:order, :tenant_id => tenant.id, :owner => 'barney') }
 
-  let!(:order_item) { create(:order_item, :order_id => order1.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
-  let!(:order_item2) { create(:order_item, :order_id => order1.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
-
   context "scoped by owner" do
     it "#by_owner" do
       ManageIQ::API::Common::Request.with_request(default_request) do
         expect(Order.by_owner.collect(&:id)).to match_array([order1.id, order2.id])
         expect(Order.all.count).to eq(3)
-      end
-    end
-  end
-
-  describe "#transition_state" do
-    before do
-      order_item.update(:state => expected_state)
-    end
-
-    let(:transition) do
-      order1.transition_state
-      order1.reload
-    end
-
-    context "when the order item's state hasn't been updated" do
-      let(:expected_state) { "Ordered" }
-
-      it "sets the state to Ordered" do
-        transition
-        expect(order1.state).to eq 'Ordered'
-      end
-    end
-
-    context "when the order item gets updated to denied" do
-      let(:expected_state) { "Denied" }
-
-      it "sets the state to Denied" do
-        transition
-        expect(order1.state).to eq 'Denied'
-      end
-
-      it "sets the state to Denied even if only one is denied" do
-        order_item2.update(:state => "Approved")
-        transition
-        expect(order1.state).to eq 'Denied'
-      end
-    end
-
-    context "when the order item gets updated to failed" do
-      let(:expected_state) { "Failed" }
-
-      it "sets the state to Failed" do
-        transition
-        expect(order1.state).to eq 'Failed'
-      end
-    end
-
-    context "when the order item gets updated to approved" do
-      let(:expected_state) { "Approved" }
-
-      it "does not transition to approved until all items are approved" do
-        transition
-        expect(order1.state).to eq 'Ordered'
-      end
-
-      it "sets the state to Approved" do
-        order_item2.update(:state => "Approved")
-        transition
-        expect(order1.state).to eq 'Approved'
-      end
-    end
-
-    context "when the order item gets updated to completed" do
-      let(:expected_state) { "Completed" }
-
-      it "does not transition to completed until all items are completed" do
-        transition
-        expect(order1.state).to eq 'Ordered'
-      end
-
-      it "sets the state to Completed" do
-        order_item2.update(:state => "Completed")
-        transition
-        expect(order1.state).to eq 'Completed'
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -4,11 +4,88 @@ describe Order do
   let!(:order2) { create(:order, :tenant_id => tenant.id) }
   let!(:order3) { create(:order, :tenant_id => tenant.id, :owner => 'barney') }
 
+  let!(:order_item) { create(:order_item, :order_id => order1.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
+  let!(:order_item2) { create(:order_item, :order_id => order1.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
+
   context "scoped by owner" do
     it "#by_owner" do
       ManageIQ::API::Common::Request.with_request(default_request) do
         expect(Order.by_owner.collect(&:id)).to match_array([order1.id, order2.id])
         expect(Order.all.count).to eq(3)
+      end
+    end
+  end
+
+  describe "#transition_state" do
+    before do
+      order_item.update(:state => expected_state)
+    end
+
+    let(:transition) do
+      order1.transition_state
+      order1.reload
+    end
+
+    context "when the order item's state hasn't been updated" do
+      let(:expected_state) { "Ordered" }
+
+      it "sets the state to Ordered" do
+        transition
+        expect(order1.state).to eq 'Ordered'
+      end
+    end
+
+    context "when the order item gets updated to denied" do
+      let(:expected_state) { "Denied" }
+
+      it "sets the state to Denied" do
+        transition
+        expect(order1.state).to eq 'Denied'
+      end
+
+      it "sets the state to Denied even if only one is denied" do
+        order_item2.update(:state => "Approved")
+        transition
+        expect(order1.state).to eq 'Denied'
+      end
+    end
+
+    context "when the order item gets updated to failed" do
+      let(:expected_state) { "Failed" }
+
+      it "sets the state to Failed" do
+        transition
+        expect(order1.state).to eq 'Failed'
+      end
+    end
+
+    context "when the order item gets updated to approved" do
+      let(:expected_state) { "Approved" }
+
+      it "does not transition to approved until all items are approved" do
+        transition
+        expect(order1.state).to eq 'Ordered'
+      end
+
+      it "sets the state to Approved" do
+        order_item2.update(:state => "Approved")
+        transition
+        expect(order1.state).to eq 'Approved'
+      end
+    end
+
+    context "when the order item gets updated to completed" do
+      let(:expected_state) { "Completed" }
+
+      it "does not transition to completed until all items are completed" do
+        transition
+        expect(order1.state).to eq 'Ordered'
+      end
+
+      it "sets the state to Completed" do
+        order_item2.update(:state => "Completed")
+        transition
+        expect(order1.state).to eq 'Completed'
       end
     end
   end

--- a/spec/services/catalog/approval_transition_spec.rb
+++ b/spec/services/catalog/approval_transition_spec.rb
@@ -35,7 +35,7 @@ describe Catalog::ApprovalTransition do
       end
 
       it "returns the state as approved" do
-        expect(order_item_transition.process.state).to eq "approved"
+        expect(order_item_transition.process.state).to eq "Approved"
       end
 
       it "calls out to Catalog::SubmitOrder" do
@@ -57,7 +57,7 @@ describe Catalog::ApprovalTransition do
       end
 
       it "returns the state as denied" do
-        expect(order_item_transition.process.state).to eq "denied"
+        expect(order_item_transition.process.state).to eq "Denied"
       end
 
       it "does not call out to submit order" do
@@ -86,7 +86,7 @@ describe Catalog::ApprovalTransition do
 
     context "when pending" do
       it "returns the state as pending" do
-        expect(order_item_transition.process.state).to eq "pending"
+        expect(order_item_transition.process.state).to eq "Pending"
       end
     end
 

--- a/spec/services/catalog/approval_transition_spec.rb
+++ b/spec/services/catalog/approval_transition_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::OrderItemTransition do
+describe Catalog::ApprovalTransition do
   let(:so) { class_double(Catalog::SubmitOrder).as_stubbed_const(:transfer_nested_constants => true) }
   let(:submit_order) { instance_double(Catalog::SubmitOrder) }
   let(:topo_ex) { Catalog::TopologyError.new("boom") }
@@ -43,6 +43,12 @@ describe Catalog::OrderItemTransition do
         expect(submit_order).to receive(:process).once
         order_item_transition.process
       end
+
+      it "finalizes the Order" do
+        order_item_transition.process
+        order.reload
+        expect(order.state).to eq("Approved")
+      end
     end
 
     context "when denied" do
@@ -69,6 +75,12 @@ describe Catalog::OrderItemTransition do
         order_item_transition.process
         order.reload
         expect(order.state).to eq "Denied"
+      end
+
+      it "finalizes the Order" do
+        order_item_transition.process
+        order.reload
+        expect(order.state).to eq("Denied")
       end
     end
 

--- a/spec/services/catalog/approval_transition_spec.rb
+++ b/spec/services/catalog/approval_transition_spec.rb
@@ -47,7 +47,7 @@ describe Catalog::ApprovalTransition do
       it "finalizes the Order" do
         order_item_transition.process
         order.reload
-        expect(order.state).to eq("Approved")
+        expect(order.state).to eq("Ordered")
       end
     end
 
@@ -71,16 +71,16 @@ describe Catalog::ApprovalTransition do
         expect(order_item.state).to eq "Denied"
       end
 
-      it "marks the order as denied" do
+      it "marks the order as failed" do
         order_item_transition.process
         order.reload
-        expect(order.state).to eq "Denied"
+        expect(order.state).to eq "Failed"
       end
 
       it "finalizes the Order" do
         order_item_transition.process
         order.reload
-        expect(order.state).to eq("Denied")
+        expect(order.state).to eq("Failed")
       end
     end
 

--- a/spec/services/catalog/order_state_transition_spec.rb
+++ b/spec/services/catalog/order_state_transition_spec.rb
@@ -1,0 +1,67 @@
+describe Catalog::OrderStateTransition do
+  let(:tenant) { create(:tenant) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
+
+  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
+  let(:order_item2) { create(:order_item, :order_id => order.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
+
+  describe "#process" do
+    before do
+      order_item.update(:state => expected_state)
+    end
+
+    let(:transition) do
+      described_class.new(order.id).process
+      order.reload
+    end
+
+    context "when the order item's state hasn't been updated" do
+      let(:expected_state) { "Ordered" }
+
+      it "sets the state to Ordered" do
+        transition
+        expect(order.state).to eq 'Ordered'
+      end
+    end
+
+    context "when the order item gets updated to denied" do
+      let(:expected_state) { "Denied" }
+
+      it "sets the state to Failed" do
+        transition
+        expect(order.state).to eq 'Failed'
+      end
+
+      it "sets the state to Failed even if only one is denied" do
+        order_item2.update(:state => "Approved")
+        transition
+        expect(order.state).to eq 'Failed'
+      end
+    end
+
+    context "when the order item gets updated to failed" do
+      let(:expected_state) { "Failed" }
+
+      it "sets the state to Failed" do
+        transition
+        expect(order.state).to eq 'Failed'
+      end
+    end
+
+    context "when the order item gets updated to completed" do
+      let(:expected_state) { "Completed" }
+
+      it "does not transition to completed until all items are completed" do
+        order_item2.update(:state => "Created")
+        transition
+        expect(order.state).to eq 'Ordered'
+      end
+
+      it "sets the state to Completed" do
+        order_item2.update(:state => "Completed")
+        transition
+        expect(order.state).to eq 'Completed'
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-368

Refactor the way we handle transitioning states on orders, always calling `state_transition` on Order whenever we modify any of the child `order_item`s, added in Denied and Approved states for `Order`/`OrderItem`.
Rename `Catalog::OrderItemStateTransition` -> `Catalog::ApprovalTransition`