### PR TITLE
Bump manageiq-loggers version to pick up request_id changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 gem 'acts_as_tenant'
 gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'master'
 gem 'jbuilder', '~> 2.0'
-gem 'manageiq-loggers', '~> 0.1'
+gem 'manageiq-loggers', '~> 0.2'
 gem 'manageiq-messaging', '~> 0.1.2', :require => false
 gem 'mimemagic', '~> 0.3.3'
 gem 'more_core_extensions', '~>3.5'


### PR DESCRIPTION
Logging will now include thread local request_id when available.

See https://github.com/ManageIQ/manageiq-loggers/pull/7 (Get the request id from the thread local variable and log it)