### PR TITLE
Sort namespaces in order selection

### DIFF
--- a/app/services/catalog/provider_control_parameters.rb
+++ b/app/services/catalog/provider_control_parameters.rb
@@ -11,7 +11,7 @@ module Catalog
       TopologicalInventory.call do |api_instance|
         # TODO: Temporay till we get this call in the topology service
         projects = api_instance.list_source_container_projects(source_ref).data
-        update_project_list(projects.collect(&:name))
+        update_project_list(project_names(projects))
         self
       end
     rescue StandardError => e
@@ -20,6 +20,10 @@ module Catalog
     end
 
     private
+
+    def project_names(projects)
+      projects.collect(&:name).sort
+    end
 
     def update_project_list(projects)
       @data = JSON.parse(read_control_parameters)

--- a/spec/services/catalog/provider_control_parameters_spec.rb
+++ b/spec/services/catalog/provider_control_parameters_spec.rb
@@ -7,13 +7,15 @@ describe Catalog::ProviderControlParameters do
   let(:params) { portfolio_item.id }
   let(:provider_control_parameters) { described_class.new(params) }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_source_ref => source_id) }
+  let(:project1_name) { 'project-one' }
+  let(:project2_name) { 'project-two' }
   let(:project1) do
-    TopologicalInventoryApiClient::ContainerProject.new('name'      => "project one",
-                                                        'source_id' => "1")
+    TopologicalInventoryApiClient::ContainerProject.new('name'      => project1_name,
+                                                        'source_id' => "2")
   end
   let(:project2) do
-    TopologicalInventoryApiClient::ContainerProject.new('name'      => "project one",
-                                                        'source_id' => "2")
+    TopologicalInventoryApiClient::ContainerProject.new('name'      => project2_name,
+                                                        'source_id' => "3")
   end
 
   let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }
@@ -27,7 +29,7 @@ describe Catalog::ProviderControlParameters do
     expect(api_instance).to receive(:list_source_container_projects).and_return(result)
 
     data = provider_control_parameters.process.data
-    expect(data['properties']['namespace']['enum'].first).to eq("project one")
+    expect(data['properties']['namespace']['enum'].first).to eq(project1_name)
   end
 
   context "invalid portfolio item" do


### PR DESCRIPTION
I noticed that the namespaces were showing up in creation order and wanted to make it more consistent/predictable.

~~Also, since we have been advised not to provision to the default namespace I thought it might be worth putting here to get feedback.  cc @brahmanim~~

This is all temporary as this code will need to move to Topology soon.