### PR TITLE
Implement Copy functionality for Portfolio Items

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -10,18 +10,18 @@ module Api
           resource_check('read')
         end
 
-        def resource_check(verb, id = params[:id], clazz = controller_name.classify.constantize)
+        def resource_check(verb, id = params[:id], klass = controller_name.classify.constantize)
           return unless RBAC::Access.enabled?
           access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
-          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{clazz}" unless access_obj.accessible?
+          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{klass}" unless access_obj.accessible?
           ids = access_obj.id_list
-          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{clazz}" if ids.any? && ids.exclude?(id)
+          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
         end
 
-        def permission_check(verb, clazz = controller_name.classify.constantize)
+        def permission_check(verb, klass = controller_name.classify.constantize)
           return unless RBAC::Access.enabled?
-          access_obj = RBAC::Access.new(clazz.table_name, verb).process
-          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{clazz}" unless access_obj.accessible?
+          access_obj = RBAC::Access.new(klass.table_name, verb).process
+          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{klass}" unless access_obj.accessible?
         end
       end
     end

--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -13,7 +13,7 @@ module Api
         def resource_check(verb, id = params[:id], klass = controller_name.classify.constantize)
           return unless RBAC::Access.enabled?
           access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
-          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{klass}" unless access_obj.accessible?
+          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
           ids = access_obj.id_list
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" if ids.any? && ids.exclude?(id)
         end
@@ -21,7 +21,7 @@ module Api
         def permission_check(verb, klass = controller_name.classify.constantize)
           return unless RBAC::Access.enabled?
           access_obj = RBAC::Access.new(klass.table_name, verb).process
-          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{klass}" unless access_obj.accessible?
+          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
         end
       end
     end

--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -2,21 +2,26 @@ module Api
   module V1x0
     module Mixins
       module RBACMixin
-
         def write_access_check
-          access_check('write')
+          resource_check('write')
         end
 
         def read_access_check
-          access_check('read')
+          resource_check('read')
         end
 
-        def access_check(verb)
+        def resource_check(verb, id = params[:id], clazz = controller_name.classify.constantize)
           return unless RBAC::Access.enabled?
           access_obj = RBAC::Access.new(controller_name.classify.constantize.table_name, verb).process
-          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{controller_name.classify.constantize}" unless access_obj.accessible?
+          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{clazz}" unless access_obj.accessible?
           ids = access_obj.id_list
-          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{controller_name.classify.constantize}" if ids.any? && ids.exclude?(params[:id])
+          raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{clazz}" if ids.any? && ids.exclude?(id)
+        end
+
+        def permission_check(verb, clazz = controller_name.classify.constantize)
+          return unless RBAC::Access.enabled?
+          access_obj = RBAC::Access.new(clazz.table_name, verb).process
+          raise Catalog::NotAuthorized, "#{verb.titleize}  access not authorized for #{clazz}" unless access_obj.accessible?
         end
       end
     end

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -44,7 +44,7 @@ module Api
       def copy
         svc = Catalog::CopyPortfolioItem.new(portfolio_copy_params)
         render :json => svc.process.new_portfolio_item
-      rescue ActiveRecord::RecordNotFound => e
+      rescue Catalog::InvalidParameter => e
         json_response({ :errors => e.message }, :unprocessable_entity)
       end
 
@@ -60,7 +60,7 @@ module Api
       end
 
       def portfolio_copy_params
-        params.permit(:portfolio_item_id, :portfolio_id)
+        params.permit(:portfolio_item_id, :portfolio_id, :portfolio_item_name)
       end
     end
   end

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -40,7 +40,7 @@ module Api
         svc = Catalog::CopyPortfolioItem.new(portfolio_copy_params)
         render :json => svc.process.new_portfolio_item
       rescue ActiveRecord::RecordNotFound => e
-        render :json => { :errors => e.message }, :status => :unprocessable_entity
+        json_response({ :errors => e.message }, :unprocessable_entity)
       end
 
       private

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -3,7 +3,12 @@ module Api
     class PortfolioItemsController < ApplicationController
       include Api::V1x0::Mixins::IndexMixin
 
-      before_action :write_access_check, :only => %i[create update destroy copy]
+      before_action :write_access_check, :only => %i[create update destroy]
+
+      before_action :only => [:copy] do
+        resource_check('read', params.require(:portfolio_item_id))
+        permission_check('write', Portfolio)
+      end
 
       def index
         if params[:portfolio_id]
@@ -55,7 +60,6 @@ module Api
       end
 
       def portfolio_copy_params
-        params.require(:portfolio_item_id)
         params.permit(:portfolio_item_id, :portfolio_id)
       end
     end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -8,16 +8,7 @@ class Portfolio < ApplicationRecord
   validates :image_url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :allow_blank => true
   validates :enabled_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
 
-  has_many :portfolio_items, :dependent => :destroy do
-    def collect_with_regex(attr, regex)
-      [].tap do |arr|
-        each do |item|
-          arr << item.send(attr) if item.send(attr).match(regex)
-        end
-        arr.compact
-      end
-    end
-  end
+  has_many :portfolio_items, :dependent => :destroy
 
   before_discard do
     if portfolio_items.map(&:discard).any? { |result| result == false }

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -8,7 +8,16 @@ class Portfolio < ApplicationRecord
   validates :image_url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :allow_blank => true
   validates :enabled_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
 
-  has_many :portfolio_items, :dependent => :destroy
+  has_many :portfolio_items, :dependent => :destroy do
+    def collect_with_regex(attr, regex)
+      [].tap do |arr|
+        each do |item|
+          arr << item.send(attr) if item.send(attr).match(regex)
+        end
+        arr.compact
+      end
+    end
+  end
 
   before_discard do
     if portfolio_items.map(&:discard).any? { |result| result == false }

--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -1,0 +1,30 @@
+module Catalog
+  class CopyPortfolioItem
+    attr_reader :new_portfolio_item
+
+    def initialize(params)
+      @portfolio_item = PortfolioItem.find(params[:portfolio_item_id])
+      @to_portfolio = Portfolio.find_by!(:id => params[:portfolio_id]) if params[:portfolio_id].present?
+    end
+
+    def process
+      @new_portfolio_item = make_copy
+      @to_portfolio.portfolio_items << @new_portfolio_item
+
+      self
+    end
+
+    private
+
+    def make_copy
+      new_portfolio_item = @portfolio_item.dup
+
+      if new_portfolio_item.portfolio_id == @to_portfolio.id
+        new_portfolio_item.name = "Copy of " + new_portfolio_item.name
+      end
+
+      new_portfolio_item.save
+      new_portfolio_item
+    end
+  end
+end

--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -40,9 +40,9 @@ module Catalog
     COPY_REGEX = '^Copy (\(\d\) )?of'.freeze
 
     def create_copy_name
-      names = @to_portfolio.portfolio_items.collect(&:name)
+      names = @to_portfolio.portfolio_items.collect_with_regex(:name, "#{COPY_REGEX} #{@portfolio_item.name.sub(COPY_REGEX, '')}")
 
-      if names.any? { |name| name.match(/#{COPY_REGEX} #{@portfolio_item.name.sub(COPY_REGEX, "")}/) }
+      if names.any?
         num = get_index(names)
         "Copy (#{num + 1}) of " + @portfolio_item.name
       else
@@ -61,7 +61,7 @@ module Catalog
       # 5. 2                                  - max
       # 6. || 0, if there weren't any numbers, let's return 0 by default.
       names
-        .map { |name| name.match(/#{COPY_REGEX} #{@portfolio_item.name.sub(COPY_REGEX, "")}/)&.captures&.first }
+        .map { |name| name.match(COPY_REGEX)&.captures&.first }
         .compact
         .map { |match| match.gsub(/(\(|\))/, "").to_i }
         .max || 0

--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -31,40 +31,10 @@ module Catalog
 
     def new_name
       if @portfolio_item.portfolio_id == @to_portfolio.id
-        create_copy_name
+        Catalog::NameAdjust.create_copy_name(@portfolio_item.name, @to_portfolio.portfolio_items.pluck(:name))
       else
         @portfolio_item.name
       end
-    end
-
-    COPY_REGEX = '^Copy (\(\d\) )?of'.freeze
-
-    def create_copy_name
-      names = @to_portfolio.portfolio_items.collect_with_regex(:name, "#{COPY_REGEX} #{@portfolio_item.name.sub(COPY_REGEX, '')}")
-
-      if names.any?
-        num = get_index(names)
-        "Copy (#{num + 1}) of " + @portfolio_item.name
-      else
-        "Copy of " + @portfolio_item.name
-      end
-    end
-
-    def get_index(names)
-      ####
-      # This chain of maps takes a match for "Copy (#) of #{name}" and returns the highest index.
-      # The chain goes as follows
-      # 1. raw names
-      # 2. [ nil, "(2)", nil, nil, "(2)" ]    - map
-      # 3. [ "(1)", "(2)" ]                   - compact
-      # 4. [ 1, 2 ]                           - map
-      # 5. 2                                  - max
-      # 6. || 0, if there weren't any numbers, let's return 0 by default.
-      names
-        .map { |name| name.match(COPY_REGEX)&.captures&.first }
-        .compact
-        .map { |match| match.gsub(/(\(|\))/, "").to_i }
-        .max || 0
     end
   end
 end

--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -4,7 +4,7 @@ module Catalog
 
     def initialize(params)
       @portfolio_item = PortfolioItem.find(params[:portfolio_item_id])
-      @to_portfolio = Portfolio.find_by!(:id => params[:portfolio_id]) if params[:portfolio_id].present?
+      @to_portfolio = Portfolio.find(params[:portfolio_id] || @portfolio_item.portfolio_id)
     end
 
     def process
@@ -17,14 +17,13 @@ module Catalog
     private
 
     def make_copy
-      new_portfolio_item = @portfolio_item.dup
+      @portfolio_item.dup.tap do |new_portfolio_item|
+        if new_portfolio_item.portfolio_id == @to_portfolio.id
+          new_portfolio_item.name = "Copy of " + new_portfolio_item.name
+        end
 
-      if new_portfolio_item.portfolio_id == @to_portfolio.id
-        new_portfolio_item.name = "Copy of " + new_portfolio_item.name
+        new_portfolio_item.save
       end
-
-      new_portfolio_item.save
-      new_portfolio_item
     end
   end
 end

--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -3,8 +3,14 @@ module Catalog
     attr_reader :new_portfolio_item
 
     def initialize(params)
+      @name = params[:portfolio_item_name]
       @portfolio_item = PortfolioItem.find(params[:portfolio_item_id])
-      @to_portfolio = Portfolio.find(params[:portfolio_id] || @portfolio_item.portfolio_id)
+
+      begin
+        @to_portfolio = Portfolio.find(params[:portfolio_id] || @portfolio_item.portfolio_id)
+      rescue ActiveRecord::RecordNotFound
+        raise Catalog::InvalidParameter, "Portfolio specified not found"
+      end
     end
 
     def process
@@ -18,12 +24,47 @@ module Catalog
 
     def make_copy
       @portfolio_item.dup.tap do |new_portfolio_item|
-        if new_portfolio_item.portfolio_id == @to_portfolio.id
-          new_portfolio_item.name = "Copy of " + new_portfolio_item.name
-        end
-
+        new_portfolio_item.name = @name || new_name
         new_portfolio_item.save
       end
+    end
+
+    def new_name
+      if @portfolio_item.portfolio_id == @to_portfolio.id
+        create_copy_name
+      else
+        @portfolio_item.name
+      end
+    end
+
+    COPY_REGEX = '^Copy (\(\d\) )?of'.freeze
+
+    def create_copy_name
+      names = @to_portfolio.portfolio_items.collect(&:name)
+
+      if names.any? { |name| name.match(/#{COPY_REGEX} #{@portfolio_item.name.sub(COPY_REGEX, "")}/) }
+        num = get_index(names)
+        "Copy (#{num + 1}) of " + @portfolio_item.name
+      else
+        "Copy of " + @portfolio_item.name
+      end
+    end
+
+    def get_index(names)
+      ####
+      # This chain of maps takes a match for "Copy (#) of #{name}" and returns the highest index.
+      # The chain goes as follows
+      # 1. raw names
+      # 2. [ nil, "(2)", nil, nil, "(2)" ]    - map
+      # 3. [ "(1)", "(2)" ]                   - compact
+      # 4. [ 1, 2 ]                           - map
+      # 5. 2                                  - max
+      # 6. || 0, if there weren't any numbers, let's return 0 by default.
+      names
+        .map { |name| name.match(/#{COPY_REGEX} #{@portfolio_item.name.sub(COPY_REGEX, "")}/)&.captures&.first }
+        .compact
+        .map { |match| match.gsub(/(\(|\))/, "").to_i }
+        .max || 0
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
         resources :provider_control_parameters, :only => [:index]
         resources :service_plans,               :only => [:index]
         get :icon, :action => 'show', :controller => 'icons'
+        post :copy, :action => 'copy', :controller => 'portfolio_items'
       end
     end
   end

--- a/lib/catalog/name_adjust.rb
+++ b/lib/catalog/name_adjust.rb
@@ -1,0 +1,36 @@
+module Catalog
+  class NameAdjust
+    COPY_REGEX = '^Copy (\(\d\) )?of'.freeze
+
+    def self.create_copy_name(original_name, names)
+      original_name.sub!(COPY_REGEX, '')
+      names.select! { |name| name.match("#{COPY_REGEX} #{original_name}") }
+
+      if names.any?
+        num = get_index(names)
+        "Copy (#{num + 1}) of " + original_name
+      else
+        "Copy of " + original_name
+      end
+    end
+
+    class << self
+      def get_index(names)
+        ####
+        # This chain of maps takes a match for "Copy (#) of #{name}" and returns the highest index.
+        # The chain goes as follows
+        # 1. raw names
+        # 2. [ nil, "(2)", nil, nil, "(2)" ]    - map
+        # 3. [ "(1)", "(2)" ]                   - compact
+        # 4. [ 1, 2 ]                           - map
+        # 5. 2                                  - max
+        # 6. || 0, if there weren't any numbers, let's return 0 by default.
+        names
+          .map { |name| name.match(COPY_REGEX)&.captures&.first }
+          .compact
+          .map { |match| match.gsub(/[()]/, "").to_i }
+          .max || 0
+      end
+    end
+  end
+end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -3,4 +3,5 @@ module Catalog
   class RBACError < StandardError; end
   class ApprovalError < StandardError; end
   class NotAuthorized < StandardError; end
+  class InvalidParameter < StandardError; end
 end

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1119,6 +1119,58 @@
           }
         }
       }
+    },
+    "/portfolio_items/{portfolio_item_id}/copy": {
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Make a copy of the Portfolio Item",
+        "operationId": "postCopyPortfolioItem",
+        "description": "Make a copy of the Portfolio Item.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new Portfolio Item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Item not found"
+          },
+          "422": {
+            "description": "Portfolio not found"
+          },
+          "500": {
+            "description": "Failed to copy Portfolio Item"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CopyPortfolioItem"
+              }
+            }
+          },
+          "required": false
+        }
+      }
     }
   },
   "servers": [
@@ -1328,6 +1380,17 @@
             "title": "Portfolio Item Id",
             "example": "100",
             "description": "This is the ID of the portfolio item object."
+          }
+        }
+      },
+      "CopyPortfolioItem": {
+        "type": "object",
+        "properties": {
+          "portfolio_id": {
+            "type": "string",
+            "title": "Portfolio ID",
+            "example": "2",
+            "description": "The portfolio to place the new copy of the Portfolio Item in"
           }
         }
       },
@@ -1542,7 +1605,7 @@
             "title": "External url",
             "description": "The external url of the service instance used with relation to this order item"
           },
-          "insights_request_id":{
+          "insights_request_id": {
             "type": "string",
             "title": "Insights Request ID ",
             "example": "364498f142194beba576833d7303abe5",

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1391,6 +1391,12 @@
             "title": "Portfolio ID",
             "example": "2",
             "description": "The portfolio to place the new copy of the Portfolio Item in"
+          },
+          "portfolio_item_name": {
+            "type": "string",
+            "title": "Portfolio Item Name",
+            "example": "nginx copy",
+            "description": "The name of the copied portfolio item"
           }
         }
       },

--- a/spec/lib/catalog/name_adjust_spec.rb
+++ b/spec/lib/catalog/name_adjust_spec.rb
@@ -1,0 +1,22 @@
+describe Catalog::NameAdjust do
+  describe "#create_copy_name" do
+    let(:item_name) { "MyItem" }
+    let(:create_copy_name) { described_class.create_copy_name(item_name, names) }
+
+    context "when passing in multiple Copy Names" do
+      let(:names) { [item_name.to_s, "Copy of #{item_name}", "Copy (1) of #{item_name}"] }
+
+      it "returns the highest index in the array" do
+        expect(create_copy_name).to eq "Copy (2) of #{item_name}"
+      end
+    end
+
+    context "when there are not any other copies" do
+      let(:names) { [item_name.to_s, "anotheritem"] }
+
+      it "returns the right copy of string" do
+        expect(create_copy_name).to eq "Copy of #{item_name}"
+      end
+    end
+  end
+end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -3,7 +3,7 @@ describe Portfolio do
   let(:tenant2)           { create(:tenant, :external_tenant => "2") }
   let(:portfolio)         { create(:portfolio, :tenant_id => tenant1.id) }
   let(:portfolio_id)      { portfolio.id }
-  let(:portfolio_item)    { create(:portfolio_item, :tenant_id => tenant1.id) }
+  let!(:portfolio_item)   { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant1.id) }
   let(:portfolio_item_id) { portfolio_item.id }
 
   context "when setting portfolio fields" do
@@ -87,6 +87,12 @@ describe Portfolio do
           expect(Portfolio.first.tenant_id).to eq tenant2.id
         end
       end
+    end
+  end
+
+  describe "portfolio_items#collect_with_regex" do
+    it "returns the portfolio_items that match the specified regex" do
+      expect(portfolio.portfolio_items.collect_with_regex(:name, "Item").count).to eq 1
     end
   end
 end

--- a/spec/models/portfolio_spec.rb
+++ b/spec/models/portfolio_spec.rb
@@ -89,10 +89,4 @@ describe Portfolio do
       end
     end
   end
-
-  describe "portfolio_items#collect_with_regex" do
-    it "returns the portfolio_items that match the specified regex" do
-      expect(portfolio.portfolio_items.collect_with_regex(:name, "Item").count).to eq 1
-    end
-  end
 end

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -1,6 +1,7 @@
 describe 'Portfolio Items RBAC API' do
   let(:tenant) { create(:tenant) }
-  let!(:portfolio_item1) { create(:portfolio_item, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio_item1) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
   let!(:portfolio_item2) { create(:portfolio_item, :tenant_id => tenant.id) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s]) }
   let(:double_access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s, portfolio_item2.id.to_s]) }
@@ -24,6 +25,39 @@ describe 'Portfolio Items RBAC API' do
       get "#{api('1.0')}/portfolio_items", :headers => default_headers
 
       expect(response).to have_http_status(403)
+    end
+  end
+
+  context "when user does not have RBAC write portfolios access" do
+    before do
+      allow(RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)
+      allow(access_obj).to receive(:process).and_return(access_obj)
+
+      allow(RBAC::Access).to receive(:new).with('portfolios', 'write').and_return(block_access_obj)
+      allow(block_access_obj).to receive(:process).and_return(block_access_obj)
+    end
+
+    it 'returns a 403' do
+      post "#{api("1.0")}/portfolio_items/#{portfolio_item1.id}/copy", :headers => default_headers
+
+      expect(response).to have_http_status(403)
+    end
+  end
+
+  context "when user has RBAC write portfolios access" do
+    let(:portfolio_access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio.id.to_s]) }
+    before do
+      allow(RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)
+      allow(access_obj).to receive(:process).and_return(access_obj)
+
+      allow(RBAC::Access).to receive(:new).with('portfolios', 'write').and_return(portfolio_access_obj)
+      allow(portfolio_access_obj).to receive(:process).and_return(portfolio_access_obj)
+    end
+
+    it 'returns a 200' do
+      post "#{api("1.0")}/portfolio_items/#{portfolio_item1.id}/copy", :headers => default_headers
+
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -45,7 +45,7 @@ describe 'Portfolio Items RBAC API' do
   end
 
   context "when user has RBAC write portfolios access" do
-    let(:portfolio_access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio.id.to_s]) }
+    let(:portfolio_access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => false, :id_list => [portfolio.id.to_s]) }
     before do
       allow(RBAC::Access).to receive(:new).with('portfolio_items', 'read').and_return(access_obj)
       allow(access_obj).to receive(:process).and_return(access_obj)

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -232,4 +232,37 @@ describe "PortfolioItemRequests", :type => :request do
       end
     end
   end
+
+  describe "copying portfolio items" do
+    let(:copy_portfolio_item) do
+      post "#{api("1.0")}/portfolio_items/#{portfolio_item.id}/copy", :params => params, :headers => default_headers
+    end
+
+    context "when copying into the same portfolio" do
+      let(:params) { { :portfolio_id => portfolio_item.portfolio_id } }
+
+      before do
+        portfolio_item.update!(:portfolio_id => "1")
+        copy_portfolio_item
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns a copy of the portfolio_item" do
+        expect(json["description"]).to eq portfolio_item.description
+        expect(json["owner"]).to eq portfolio_item.owner
+        expect(json["workflow_ref"]).to eq portfolio_item.workflow_ref
+      end
+
+      it "modifies the name to not collide" do
+        expect(json["name"]).to_not eq portfolio_item.name
+        expect(json["name"]).to match(/^Copy of.*/)
+      end
+    end
+
+    context "when copying into a different portfolio" do
+    end
+  end
 end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -270,21 +270,6 @@ describe "PortfolioItemRequests", :type => :request do
       end
     end
 
-    context "when copying an item multiple times" do
-      let(:params) { { :portfolio_id => portfolio.id } }
-      let!(:another_portfolio_item) do
-        create(:portfolio_item,
-               :tenant_id    => tenant.id,
-               :portfolio_id => portfolio.id,
-               :name         => "Copy of #{portfolio_item.name}")
-      end
-
-      it "adds a (1) to the name if there is already a copy" do
-        copy_portfolio_item
-        expect(json["name"]).to eq "Copy (1) of #{portfolio_item.name}"
-      end
-    end
-
     context "when copying into a different portfolio" do
       let(:params) { { :portfolio_id => new_portfolio.id } }
       let(:new_portfolio) { create(:portfolio, :tenant_id => tenant.id) }

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -261,6 +261,30 @@ describe "PortfolioItemRequests", :type => :request do
       end
     end
 
+    context "when copying with a specified name" do
+      let(:params) { { :portfolio_item_name => "NewPortfolioItem" } }
+
+      it "returns the name specified" do
+        copy_portfolio_item
+        expect(json["name"]).to eq params[:portfolio_item_name]
+      end
+    end
+
+    context "when copying an item multiple times" do
+      let(:params) { { :portfolio_id => portfolio.id } }
+      let!(:another_portfolio_item) do
+        create(:portfolio_item,
+               :tenant_id    => tenant.id,
+               :portfolio_id => portfolio.id,
+               :name         => "Copy of #{portfolio_item.name}")
+      end
+
+      it "adds a (1) to the name if there is already a copy" do
+        copy_portfolio_item
+        expect(json["name"]).to eq "Copy (1) of #{portfolio_item.name}"
+      end
+    end
+
     context "when copying into a different portfolio" do
       let(:params) { { :portfolio_id => new_portfolio.id } }
       let(:new_portfolio) { create(:portfolio, :tenant_id => tenant.id) }

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -15,6 +15,7 @@ describe "PortfolioItemRequests", :type => :request do
   let(:portfolio_item) do
     create(:portfolio_item, :service_offering_ref        => service_offering_ref,
                             :service_offering_source_ref => service_offering_source_ref,
+                            :portfolio_id                => portfolio.id,
                             :tenant_id                   => tenant.id)
   end
   let(:portfolio_item_id)    { portfolio_item.id }
@@ -100,7 +101,6 @@ describe "PortfolioItemRequests", :type => :request do
       it 'is still present in the db, just with deleted_at set' do
         expect(PortfolioItem.with_discarded.find_by(:id => portfolio_item_id).discarded_at).to_not be_nil
       end
-
     end
   end
 
@@ -239,10 +239,9 @@ describe "PortfolioItemRequests", :type => :request do
     end
 
     context "when copying into the same portfolio" do
-      let(:params) { { :portfolio_id => portfolio_item.portfolio_id } }
+      let(:params) { { :portfolio_id => portfolio.id } }
 
       before do
-        portfolio_item.update!(:portfolio_id => "1")
         copy_portfolio_item
       end
 
@@ -263,6 +262,39 @@ describe "PortfolioItemRequests", :type => :request do
     end
 
     context "when copying into a different portfolio" do
+      let(:params) { { :portfolio_id => new_portfolio.id } }
+      let(:new_portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+
+      before do
+        copy_portfolio_item
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns a copy of the portfolio_item" do
+        expect(json["description"]).to eq portfolio_item.description
+        expect(json["owner"]).to eq portfolio_item.owner
+        expect(json["workflow_ref"]).to eq portfolio_item.workflow_ref
+      end
+
+      it "does not modify the name" do
+        expect(json["name"]).to eq portfolio_item.name
+      end
+    end
+
+    context "when copying into a different portfolio in a different tenant" do
+      let(:params) { { :portfolio_id => not_my_portfolio.id } }
+      let(:not_my_portfolio) { create(:portfolio) }
+
+      before do
+        copy_portfolio_item
+      end
+
+      it 'returns a 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 end

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -1,12 +1,14 @@
 describe Catalog::CopyPortfolioItem do
   let(:tenant) { create(:tenant) }
-  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => "1", :tenant_id => 1) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => 1) }
 
   let(:copy_portfolio_item) { described_class.new(params).process }
 
   describe "#process" do
     context "when copying into the same portfolio" do
-      let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => "1" } }
+      let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio.id } }
 
       it "makes a copy of the portfolio_item" do
         new = copy_portfolio_item.new_portfolio_item
@@ -21,7 +23,7 @@ describe Catalog::CopyPortfolioItem do
     end
 
     context "when copying into a different portfolio" do
-      let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => "2" } }
+      let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio2.id } }
 
       it "makes a complete copy of the portfolio_item" do
         new = copy_portfolio_item.new_portfolio_item

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -1,0 +1,35 @@
+describe Catalog::CopyPortfolioItem do
+  let(:tenant) { create(:tenant) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => "1", :tenant_id => 1) }
+
+  let(:copy_portfolio_item) { described_class.new(params).process }
+
+  describe "#process" do
+    context "when copying into the same portfolio" do
+      let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => "1" } }
+
+      it "makes a copy of the portfolio_item" do
+        new = copy_portfolio_item.new_portfolio_item
+
+        expect(new.description).to eq portfolio_item.description
+        expect(new.owner).to eq portfolio_item.owner
+      end
+
+      it "modifies the name with 'Copy of'" do
+        expect(copy_portfolio_item.new_portfolio_item.name).to match(/^Copy of.*/)
+      end
+    end
+
+    context "when copying into a different portfolio" do
+      let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => "2" } }
+
+      it "makes a complete copy of the portfolio_item" do
+        new = copy_portfolio_item.new_portfolio_item
+
+        expect(new.description).to eq portfolio_item.description
+        expect(new.owner).to eq portfolio_item.owner
+        expect(copy_portfolio_item.new_portfolio_item.name).to eq portfolio_item.name
+      end
+    end
+  end
+end

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -8,6 +8,10 @@ describe Catalog::CopyPortfolioItem do
 
   describe "#process" do
     context "when copying into the same portfolio" do
+      around do |example|
+        bypass_rbac { example.call }
+      end
+
       let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio.id } }
 
       it "makes a copy of the portfolio_item" do
@@ -23,6 +27,10 @@ describe Catalog::CopyPortfolioItem do
     end
 
     context "when copying into a different portfolio" do
+      around do |example|
+        bypass_rbac { example.call }
+      end
+
       let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio2.id } }
 
       it "makes a complete copy of the portfolio_item" do

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -2,7 +2,7 @@ describe Catalog::CopyPortfolioItem do
   let(:tenant) { create(:tenant) }
   let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
   let(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => 1) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
 
   let(:copy_portfolio_item) { described_class.new(params).process }
 
@@ -40,6 +40,25 @@ describe Catalog::CopyPortfolioItem do
         expect(new.owner).to eq portfolio_item.owner
         expect(copy_portfolio_item.new_portfolio_item.name).to eq portfolio_item.name
       end
+    end
+  end
+
+  describe "#get_index" do
+    let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio2.id } }
+
+    it "gets the index for the names" do
+      names = ["Copy of #{portfolio_item.name}",
+               portfolio_item.name.to_s,
+               "Copy (2) of #{portfolio_item.name}",
+               "Copy (1) of #{portfolio_item.name}"]
+      index = copy_portfolio_item.send(:get_index, names)
+      expect(index).to eq 2
+    end
+
+    it "returns 0 if there isn't more than one copy yet" do
+      names = ["Copy of #{portfolio_item.name}", portfolio_item.name.to_s]
+      index = copy_portfolio_item.send(:get_index, names)
+      expect(index).to eq 0
     end
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-371

Adds this endpoint:
`POST /portfolio_items/{portfolio_item_id}/copy` with optional params `{ :portfolio_id => somenumber, :portfolio_item_name => "NewName" }`

which takes in a `portfolio_id` optionally and creates a copy of the `portfolio_item` specified and places it in the specified portfolio (if specified, otherwise in the same portfolio with a different name).

**### TODO**:
- [x] Add RBAC check on portfolio if specified
- [x] add tenant check on portfolio