### PR TITLE
Use .find instead of .where and handle RecordNotFound with 404

### DIFF
--- a/app/controllers/api/v1x0/approval_requests_controller.rb
+++ b/app/controllers/api/v1x0/approval_requests_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::V1x0::Mixins::IndexMixin
 
       def index
-        collection(ApprovalRequest.where(:order_item_id => params.require(:order_item_id)))
+        collection(OrderItem.find(params.require(:order_item_id)).approval_requests)
       end
     end
   end

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       def index
         if params[:portfolio_id]
-          collection(PortfolioItem.where(:portfolio_id => params.require(:portfolio_id)))
+          collection(Portfolio.find(params.require(:portfolio_id)).portfolio_items)
         else
           collection(PortfolioItem.all)
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include Response
+  include ExceptionHandler
   include Api::V1x0::Mixins::RBACMixin
   rescue_from Catalog::TopologyError, :with => :topology_service_error
   rescue_from Catalog::NotAuthorized, :with => :forbidden_error

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,10 @@
+module ExceptionHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound do |err|
+      Rails.logger.error("Not found: #{err.message}")
+      json_response({:message => "Not Found"}, :not_found)
+    end
+  end
+end

--- a/spec/requests/approval_request_spec.rb
+++ b/spec/requests/approval_request_spec.rb
@@ -1,4 +1,4 @@
-describe "ProgressMessageRequests", :type => :request do
+describe "ApprovalRequestRequests", :type => :request do
   around do |example|
     bypass_rbac do
       example.call
@@ -9,22 +9,22 @@ describe "ProgressMessageRequests", :type => :request do
   let(:order) { create(:order, :tenant_id => tenant.id) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
-  let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
+  let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
 
   context "v1.0" do
     it "lists progress messages" do
-      get "/#{api}/order_items/#{order_item.id}/progress_messages", :headers => default_headers
+      get "/#{api}/order_items/#{order_item.id}/approval_requests", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)['data'].first['id']).to eq(progress_message.id.to_s)
+      expect(JSON.parse(response.body)['data'].first['id']).to eq(approval_request.id.to_s)
     end
 
     context "when the order item does not exist" do
       let(:order_item_id) { 0 }
 
       it "returns a 404" do
-        get "/#{api}/order_items/#{order_item_id}/progress_messages", :headers => default_headers
+        get "/#{api}/order_items/#{order_item_id}/approval_requests", :headers => default_headers
 
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -23,12 +23,26 @@ describe "OrderItemsRequests", :type => :request do
 
   describe "CRUD" do
     context "when listing order_items" do
-      it "lists order items under an order" do
-        get "/api/v1.0/orders/#{order_1.id}/order_items", :headers => default_headers
+      describe "GET /orders/:order_id/order_items" do
+        it "lists order items under an order" do
+          get "/api/v1.0/orders/#{order_1.id}/order_items", :headers => default_headers
 
-        expect(response.content_type).to eq("application/json")
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['data'].first['id']).to eq(order_item_1.id.to_s)
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)['data'].first['id']).to eq(order_item_1.id.to_s)
+        end
+
+        context "when the order does not exist" do
+          let(:order_id) { 0 }
+
+          it "returns a 404" do
+            get "/api/v1.0/orders/#{order_id}/order_items", :headers => default_headers
+
+            expect(response.content_type).to eq("application/json")
+            expect(JSON.parse(response.body)["message"]).to eq("Not Found")
+            expect(response).to have_http_status(:not_found)
+          end
+        end
       end
 
       it "list all order items by tenant" do
@@ -68,25 +82,6 @@ describe "OrderItemsRequests", :type => :request do
         get "/api/v1.0/order_items/#{order_item_1.id}", :headers => default_headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
-      end
-    end
-  end
-
-  describe "#approval_requests" do
-    let!(:approval) { create(:approval_request, :order_item_id => order_item_1.id, :workflow_ref => "1", :tenant_id => tenant.id) }
-
-    context "list" do
-      before do
-        get "#{api}/order_items/#{order_item_1.id}/approval_requests", :headers => default_headers
-      end
-
-      it "returns a 200 http status" do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "lists approval requests" do
-        expect(json["data"].count).to eq 1
-        expect(json["data"].first["id"]).to eq approval.id.to_s
       end
     end
   end


### PR DESCRIPTION
Related to https://projects.engineering.redhat.com/browse/SSP-240. After digging into it a bit, I found that some `index` calls were using `.where` versus `.find`, and thus `.where` does not cause an exception to be thrown when the resource cannot be found.

After talking with @syncrou a bit about it, he asked me to fix all the various places that are using the `.where`.

@syncrou Please review, I ended up having to move around a few specs and add specs in other places that didn't already have coverage. There's also two other index requests I'm not sure how we should handle, `provider_control_parameters` and `service_plans`. Both of these use a service and the requests are currently not tested that I can see. I felt like adding the specs for these was outside the scope of this change. I did, however, add the `ExceptionHandler` in this PR, and will move the other exceptions currently in the `Response` concern into it in a separate PR.