### PR TITLE
Pulling out an around block and ClimateConfig

### DIFF
--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -24,11 +24,9 @@ describe "OpenAPI stuff" do
     let(:app_name)    { "catalog" }
     let(:path_prefix) { "/api" }
 
-    around do |example|
-      with_modified_env :PATH_PREFIX => path_prefix, :APP_NAME => app_name do
-        Rails.application.reload_routes!
-        example.call
-      end
+    before do
+      stub_const("ENV", ENV.to_h.merge("PATH_PREFIX" => path_prefix, "APP_NAME" => app_name))
+      Rails.application.reload_routes!
     end
 
     after(:all) do
@@ -45,10 +43,13 @@ describe "OpenAPI stuff" do
     end
 
     context "customizable route prefixes" do
+      let(:path_prefix) { random_path_part }
+      let(:app_name)    { random_path }
+
       it "with a random prefix" do
         expect(ENV["PATH_PREFIX"]).not_to be_nil
         expect(ENV["APP_NAME"]).not_to be_nil
-        expect(api_v1x0_orders_url(:only_path => true)).to eq("#{URI.encode(ENV["PATH_PREFIX"])}/#{URI.encode(ENV["APP_NAME"])}/v1.0/orders")
+        expect(api_v1x0_orders_url(:only_path => true)).to eq("/#{URI.encode(ENV["PATH_PREFIX"])}/#{URI.encode(ENV["APP_NAME"])}/v1.0/orders")
       end
 
       it "with extra slashes" do


### PR DESCRIPTION
There appears to be issue cleaning up the environment vars set with `ClimateConfig` ( `with_modified_env` ) in an around block.  `stub_const` also does not support around blocks.
I pulled both the `around` and `ClimateConfig` to bring the specs stable again.
As depending on order any number were failing due to environment variable poisoning.

Also discussed with @lindgrenj6 as he was seeing the same issues in his local environment.