### PR TITLE
Add Operations to undelete discarded Portfolio Items

### DIFF
--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -37,8 +37,10 @@ module Api
       end
 
       def destroy
-        PortfolioItem.find(params.require(:id)).discard
-        head :no_content
+        item = PortfolioItem.find(params.require(:id))
+        soft_delete = Catalog::SoftDelete.new(item)
+
+        render :json => { :restore_key => soft_delete.process.restore_key }
       end
 
       def copy
@@ -50,7 +52,8 @@ module Api
 
       def undestroy
         item = PortfolioItem.with_discarded.discarded.find(params.require(:portfolio_item_id))
-        item.undiscard
+        Catalog::SoftDeleteRestore.new(item, params.require(:restore_key)).process
+
         render :json => item
       end
 

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -48,6 +48,12 @@ module Api
         json_response({ :errors => e.message }, :unprocessable_entity)
       end
 
+      def undestroy
+        item = PortfolioItem.with_discarded.discarded.find(params.require(:portfolio_item_id))
+        item.undiscard
+        render :json => item
+      end
+
       private
 
       def portfolio_item_params

--- a/app/services/catalog/soft_delete.rb
+++ b/app/services/catalog/soft_delete.rb
@@ -1,0 +1,16 @@
+module Catalog
+  class SoftDelete
+    attr_reader :restore_key
+
+    def initialize(record)
+      @record = record
+    end
+
+    def process
+      @record.discard
+      @restore_key = Digest::SHA1.hexdigest(@record.discarded_at.to_s)
+
+      self
+    end
+  end
+end

--- a/app/services/catalog/soft_delete_restore.rb
+++ b/app/services/catalog/soft_delete_restore.rb
@@ -1,0 +1,18 @@
+module Catalog
+  class SoftDeleteRestore
+    def initialize(record, restore_key)
+      @record = record
+      @restore_key = restore_key
+    end
+
+    def process
+      if @restore_key == Digest::SHA1.hexdigest(@record.discarded_at.to_s)
+        @record.undiscard
+      else
+        raise Catalog::NotAuthorized, "Wrong key to restore deleted record #{@record.id}"
+      end
+
+      self
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
         resources :service_plans,               :only => [:index]
         get :icon, :action => 'show', :controller => 'icons'
         post :copy, :action => 'copy', :controller => 'portfolio_items'
+        get :undelete, :action => 'undestroy', :controller => 'portfolio_items'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
         resources :service_plans,               :only => [:index]
         get :icon, :action => 'show', :controller => 'icons'
         post :copy, :action => 'copy', :controller => 'portfolio_items'
-        get :undelete, :action => 'undestroy', :controller => 'portfolio_items'
+        post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
       end
     end
   end

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -562,8 +562,15 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Portfolio item deleted."
+          "200": {
+            "description": "Portfolio item deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreKey"
+                }
+              }
+            }
           },
           "404": {
             "description": "Portfolio item not found."
@@ -698,11 +705,11 @@
       }
     },
     "/portfolio_items/{portfolio_item_id}/undelete": {
-      "get": {
+      "post": {
         "tags": [
           "PortfolioItem"
         ],
-        "summary": "UnDelete a specified Portfolio Item",
+        "summary": "Undelete a specified Portfolio Item",
         "description": "If a record has been discarded, this operation will undelete it so it can be requested normally.",
         "parameters": [
           {
@@ -732,6 +739,16 @@
           "500": {
             "description": "Failed to undelete Portfolio Item"
           }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreKey"
+              }
+            }
+          },
+          "required": true
         }
       }
     },
@@ -1435,6 +1452,17 @@
             "title": "Portfolio Item Name",
             "example": "nginx copy",
             "description": "The name of the copied portfolio item"
+          }
+        }
+      },
+      "RestoreKey": {
+        "type": "object",
+        "properties": {
+          "restore_key": {
+            "type": "string",
+            "readOnly": true,
+            "title": "Restore Key",
+            "example": "3c1d765c1453916143e517bfc27b57ace3da693c"
           }
         }
       },

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -697,6 +697,44 @@
         }
       }
     },
+    "/portfolio_items/{portfolio_item_id}/undelete": {
+      "get": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "UnDelete a specified Portfolio Item",
+        "description": "If a record has been discarded, this operation will undelete it so it can be requested normally.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The undeleted Portfolio Item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio Item not found"
+          },
+          "500": {
+            "description": "Failed to undelete Portfolio Item"
+          }
+        }
+      }
+    },
     "/orders": {
       "get": {
         "tags": [

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -86,33 +86,35 @@ describe "PortfolioItemRequests", :type => :request do
   end
 
   describe 'DELETE admin tagged /portfolio_items/:portfolio_item_id' do
-    # TODO: https://github.com/ManageIQ/catalog-api/issues/85
-    let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'description for patched portfolio' } }
-
     context 'when v1.0 :portfolio_item_id is valid' do
       before do
-        delete "#{api}/portfolio_items/#{portfolio_item_id}", :headers => default_headers, :params => valid_attributes
+        delete "#{api}/portfolio_items/#{portfolio_item_id}", :headers => default_headers
       end
 
       it 'discards the record' do
-        expect(response).to have_http_status(204)
+        expect(response).to have_http_status(:ok)
       end
 
       it 'is still present in the db, just with deleted_at set' do
         expect(PortfolioItem.with_discarded.find_by(:id => portfolio_item_id).discarded_at).to_not be_nil
       end
+
+      it 'returns the restore_key in the body' do
+        expect(json["restore_key"]).to eq Digest::SHA1.hexdigest(PortfolioItem.with_discarded.find(portfolio_item_id).discarded_at.to_s)
+      end
     end
   end
 
-  describe 'GET /portfolio_items/{portfolio_item_id}/undelete' do
-    let(:undelete) { get "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :headers => default_headers }
-
-    before do
-      delete "#{api}/portfolio_items/#{portfolio_item_id}", :headers => default_headers
-      undelete
-    end
+  describe 'POST /portfolio_items/{portfolio_item_id}/undelete' do
+    let(:undelete) { post "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :params => { :restore_key => restore_key }, :headers => default_headers }
+    let(:restore_key) { Digest::SHA1.hexdigest(portfolio_item.discarded_at.to_s) }
 
     context "when restoring a portfolio_item that has been discarded" do
+      before do
+        portfolio_item.discard
+        undelete
+      end
+
       it "returns a 200" do
         expect(response).to have_http_status :ok
       end
@@ -123,9 +125,22 @@ describe "PortfolioItemRequests", :type => :request do
       end
     end
 
+    context 'when attempting to restore with the wrong restore_key' do
+      let(:restore_key) { "MrMaliciousRestoreKey" }
+
+      before do
+        portfolio_item.discard
+        undelete
+      end
+
+      it "returns a 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context 'when attempting to restore a portfolio_item that not been discarded' do
       it "returns a 404" do
-        get "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :headers => default_headers
+        undelete
         expect(response).to have_http_status :not_found
       end
     end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -104,6 +104,33 @@ describe "PortfolioItemRequests", :type => :request do
     end
   end
 
+  describe 'GET /portfolio_items/{portfolio_item_id}/undelete' do
+    let(:undelete) { get "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :headers => default_headers }
+
+    before do
+      delete "#{api}/portfolio_items/#{portfolio_item_id}", :headers => default_headers
+      undelete
+    end
+
+    context "when restoring a portfolio_item that has been discarded" do
+      it "returns a 200" do
+        expect(response).to have_http_status :ok
+      end
+
+      it "returns the undeleted portfolio_item" do
+        expect(json["id"]).to eq portfolio_item_id.to_s
+        expect(json["name"]).to eq portfolio_item.name
+      end
+    end
+
+    context 'when attempting to restore a portfolio_item that not been discarded' do
+      it "returns a 404" do
+        get "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :headers => default_headers
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+
   describe 'GET portfolio items' do
     context "v1.0" do
       it "success" do

--- a/spec/services/catalog/soft_delete_restore_spec.rb
+++ b/spec/services/catalog/soft_delete_restore_spec.rb
@@ -1,0 +1,20 @@
+describe Catalog::SoftDeleteRestore do
+  let(:tenant) { create(:tenant) }
+  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :discarded_at => Time.current) }
+
+  describe "#process" do
+    context "when restoring a soft-deleted record" do
+      let!(:svc) { described_class.new(portfolio_item, Digest::SHA1.hexdigest(portfolio_item.discarded_at.to_s)).process }
+
+      it "restores the record" do
+        expect(portfolio_item.discarded?).to be_falsey
+      end
+    end
+
+    context "when attempting to restore a record with the wrong SHA hash" do
+      it "raises a NotAuthorized exception" do
+        expect { described_class.new(portfolio_item, "MrMaliciousHash").process }.to raise_exception(Catalog::NotAuthorized)
+      end
+    end
+  end
+end

--- a/spec/services/catalog/soft_delete_spec.rb
+++ b/spec/services/catalog/soft_delete_spec.rb
@@ -1,0 +1,18 @@
+describe Catalog::SoftDelete do
+  let(:tenant) { create(:tenant) }
+  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
+
+  describe "#process" do
+    context "when soft-deleting a record" do
+      let!(:subject) { described_class.new(portfolio_item).process }
+
+      it "discards the record" do
+        expect(portfolio_item.discarded?).to be_truthy
+      end
+
+      it "sets the restore_key to the hash of the discarded_at column" do
+        expect(subject.restore_key).to eq Digest::SHA1.hexdigest(portfolio_item.discarded_at.to_s)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-170

This PR adds two endpoints:
~`GET /portfolio_items/discarded` which returns a collection of the discarded portfolio items~ 
`POST /portfolio_items/{portfolio_item_id}/undelete` with params `{ :restore_key => "someSha1Hash" }`which undiscards the referenced portfolio item, 

It also modifies the `DELETE /portfolio_items/{id}` endpoint to return a 200 and a body that consists of a `restore_key`. That way only the user who deleted the objects can restore them. The restore_key is just a SHA1 digest of the `PortfolioItem.discarded_at` column. So it's down to the second. Can add salt to taste if necessary :P 