### PR TITLE
Add Operations to undelete discarded Portfolios

### DIFF
--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -15,6 +15,10 @@ module Api
         collection(Portfolio.all)
       end
 
+      def discarded_index
+        collection(Portfolio.with_discarded.discarded.all)
+      end
+
       def add_portfolio_item_to_portfolio
         portfolio = Portfolio.find(params.require(:portfolio_id))
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
@@ -46,6 +50,15 @@ module Api
         portfolio = Portfolio.find(params.require(:id))
         if portfolio.discard
           head :no_content
+        else
+          render :json => { :errors => portfolio.errors }, :status => :unprocessable_entity
+        end
+      end
+
+      def undestroy
+        portfolio = Portfolio.with_discarded.discarded.find(params.require(:portfolio_id))
+        if portfolio.undiscard
+          render :json => portfolio
         else
           render :json => { :errors => portfolio.errors }, :status => :unprocessable_entity
         end

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -47,22 +47,14 @@ module Api
         svc = Catalog::SoftDelete.new(portfolio)
         key = svc.process.restore_key
 
-        if portfolio.discarded?
-          render :json => { :restore_key => key }
-        else
-          render :json => { :errors => portfolio.errors }, :status => :unprocessable_entity
-        end
+        render :json => { :restore_key => key }
       end
 
-      def undestroy
+      def restore
         portfolio = Portfolio.with_discarded.discarded.find(params.require(:portfolio_id))
         Catalog::SoftDeleteRestore.new(portfolio, params.require(:restore_key)).process
 
-        if !portfolio.discarded?
-          render :json => portfolio
-        else
-          render :json => { :errors => portfolio.errors }, :status => :unprocessable_entity
-        end
+        render :json => portfolio
       end
 
       def share

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -18,6 +18,10 @@ module ExceptionHandler
       Rails.logger.error("Unauthorized error: #{err.message}")
       json_response({:message => "Unauthorized"}, :unauthorized)
     end
+
+    rescue_from Discard::DiscardError do |err|
+      json_response({:message => err.message}, :unprocessable_entity)
+    end
   end
 
   private

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -21,6 +21,17 @@ class Portfolio < ApplicationRecord
     end
   end
 
+  before_undiscard do
+    if portfolio_items.with_discarded.discarded.map(&:undiscard).any? { |result| result == false }
+      portfolio_items.with_discarded.discarded.each do |item|
+        errors.add(item.name.to_sym, "PortfolioItem ID #{item.id}: #{item.name} failed to be restored")
+      end
+
+      Rails.logger.error("Failed to restore items from Portfolio '#{name}' id: #{id} - not undiscarding portfolio")
+      throw :abort
+    end
+  end
+
   def add_portfolio_item(portfolio_item_id)
     portfolio_item = PortfolioItem.find_by(id: portfolio_item_id)
     portfolio_items << portfolio_item

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -10,7 +10,18 @@ class Portfolio < ApplicationRecord
 
   has_many :portfolio_items, :dependent => :destroy
 
-  before_discard do
+  before_discard :discard_portfolio_items
+  before_undiscard :undiscard_portfolio_items
+
+  def add_portfolio_item(portfolio_item)
+    portfolio_items << portfolio_item
+  end
+
+  private
+
+  CHILD_DISCARD_TIME_LIMIT = 30
+
+  def discard_portfolio_items
     if portfolio_items.map(&:discard).any? { |result| result == false }
       portfolio_items.kept.each do |item|
         errors.add(item.name.to_sym, "PortfolioItem ID #{item.id}: #{item.name} failed to be discarded")
@@ -21,9 +32,9 @@ class Portfolio < ApplicationRecord
     end
   end
 
-  before_undiscard do
-    if portfolio_items.with_discarded.discarded.map(&:undiscard).any? { |result| result == false }
-      portfolio_items.with_discarded.discarded.each do |item|
+  def undiscard_portfolio_items
+    if portfolio_items_to_undelete.map(&:undiscard).any? { |result| result == false }
+      portfolio_items_to_undelete.select(&:discarded?).each do |item|
         errors.add(item.name.to_sym, "PortfolioItem ID #{item.id}: #{item.name} failed to be restored")
       end
 
@@ -32,8 +43,10 @@ class Portfolio < ApplicationRecord
     end
   end
 
-  def add_portfolio_item(portfolio_item_id)
-    portfolio_item = PortfolioItem.find_by(id: portfolio_item_id)
-    portfolio_items << portfolio_item
+  def portfolio_items_to_undelete
+    portfolio_items
+      .with_discarded
+      .discarded
+      .select { |item| (item.discarded_at.to_i - discarded_at.to_i).abs < CHILD_DISCARD_TIME_LIMIT }
   end
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -27,23 +27,25 @@ class Portfolio < ApplicationRecord
         errors.add(item.name.to_sym, "PortfolioItem ID #{item.id}: #{item.name} failed to be discarded")
       end
 
-      Rails.logger.error("Failed to discard items from Portfolio '#{name}' id: #{id} - not discarding portfolio")
-      throw :abort
+      err = "Failed to discard items from Portfolio '#{name}' id: #{id} - not discarding portfolio"
+      Rails.logger.error(err)
+      raise Discard::DiscardError, err
     end
   end
 
   def undiscard_portfolio_items
-    if portfolio_items_to_undelete.map(&:undiscard).any? { |result| result == false }
-      portfolio_items_to_undelete.select(&:discarded?).each do |item|
+    if portfolio_items_to_restore.map(&:undiscard).any? { |result| result == false }
+      portfolio_items_to_restore.select(&:discarded?).each do |item|
         errors.add(item.name.to_sym, "PortfolioItem ID #{item.id}: #{item.name} failed to be restored")
       end
 
-      Rails.logger.error("Failed to restore items from Portfolio '#{name}' id: #{id} - not undiscarding portfolio")
-      throw :abort
+      err = "Failed to restore items from Portfolio '#{name}' id: #{id} - not restoring portfolio"
+      Rails.logger.error(err)
+      raise Discard::DiscardError, err
     end
   end
 
-  def portfolio_items_to_undelete
+  def portfolio_items_to_restore
     portfolio_items
       .with_discarded
       .discarded

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       resources :portfolios,            :only => [:create, :destroy, :index, :show, :update] do
         resources :portfolio_items,       :only => [:index]
         post :copy, :action => 'copy', :controller => 'portfolios'
-        post :undelete, :action => 'undestroy', :controller => 'portfolios'
+        post :undelete, :action => 'restore', :controller => 'portfolios'
       end
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,9 +26,11 @@ Rails.application.routes.draw do
       post '/portfolios/:portfolio_id/share', :action => 'share', :controller => 'portfolios', :as => 'share'
       post '/portfolios/:portfolio_id/unshare', :action => 'unshare', :controller => 'portfolios', :as => 'unshare'
       get '/portfolios/:portfolio_id/share_info', :action => 'share_info', :controller => 'portfolios', :as => 'share_info'
+      get '/portfolios/discarded', :action => 'discarded_index', :controller => 'portfolios'
       resources :portfolios,            :only => [:create, :destroy, :index, :show, :update] do
         resources :portfolio_items,       :only => [:index]
         post :copy, :action => 'copy', :controller => 'portfolios'
+        get :undelete, :action => 'undestroy', :controller => 'portfolios'
       end
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,11 +26,10 @@ Rails.application.routes.draw do
       post '/portfolios/:portfolio_id/share', :action => 'share', :controller => 'portfolios', :as => 'share'
       post '/portfolios/:portfolio_id/unshare', :action => 'unshare', :controller => 'portfolios', :as => 'unshare'
       get '/portfolios/:portfolio_id/share_info', :action => 'share_info', :controller => 'portfolios', :as => 'share_info'
-      get '/portfolios/discarded', :action => 'discarded_index', :controller => 'portfolios'
       resources :portfolios,            :only => [:create, :destroy, :index, :show, :update] do
         resources :portfolio_items,       :only => [:index]
         post :copy, :action => 'copy', :controller => 'portfolios'
-        get :undelete, :action => 'undestroy', :controller => 'portfolios'
+        post :undelete, :action => 'undestroy', :controller => 'portfolios'
       end
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -126,6 +126,45 @@
         }
       }
     },
+    "/portfolios/discarded": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "List discarded portfolios",
+        "operationId": "listDiscardedPortfolios",
+        "description": "Gets a list of discarded portfolios.\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of discarded portfolios. An empty list indicate either undefined portfolios in the system or inaccessibility to the caller.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfoliosCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
     "/portfolios/{id}": {
       "get": {
         "tags": [
@@ -468,6 +507,45 @@
           },
           "500": {
             "description": "Failed to copy Portfolio"
+          }
+        }
+      }
+    },
+    "/portfolios/{id}/undelete": {
+      "get": {
+        "tags": [
+          "Portfolio"
+        ],
+        "summary": "UnDelete specific portfolio",
+        "operationId": "unDeletePortfolio",
+        "description": "UnDeletes the portfolio specified by the portfolio ID.\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The undeleted portfolio",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Portfolio not found."
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidEntity"
           }
         }
       }

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -126,45 +126,6 @@
         }
       }
     },
-    "/portfolios/discarded": {
-      "get": {
-        "tags": [
-          "Portfolio"
-        ],
-        "summary": "List discarded portfolios",
-        "operationId": "listDiscardedPortfolios",
-        "description": "Gets a list of discarded portfolios.\n",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/QueryLimit"
-          },
-          {
-            "$ref": "#/components/parameters/QueryOffset"
-          },
-          {
-            "$ref": "#/components/parameters/QueryFilter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns a list of discarded portfolios. An empty list indicate either undefined portfolios in the system or inaccessibility to the caller.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PortfoliosCollection"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
     "/portfolios/{id}": {
       "get": {
         "tags": [
@@ -261,8 +222,15 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Portfolio Deleted."
+          "200": {
+            "description": "Portfolio Deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreKey"
+                }
+              }
+            }
           },
           "404": {
             "description": "Portfolio Not Found."
@@ -512,13 +480,13 @@
       }
     },
     "/portfolios/{id}/undelete": {
-      "get": {
+      "post": {
         "tags": [
           "Portfolio"
         ],
-        "summary": "UnDelete specific portfolio",
+        "summary": "Undelete specific portfolio",
         "operationId": "unDeletePortfolio",
-        "description": "UnDeletes the portfolio specified by the portfolio ID.\n",
+        "description": "Undeletes the portfolio specified by the portfolio ID.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -547,6 +515,16 @@
           "422": {
             "$ref": "#/components/responses/InvalidEntity"
           }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreKey"
+              }
+            }
+          },
+          "required": true
         }
       }
     },

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -196,6 +196,21 @@ describe 'Portfolios API' do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context "when restoring a portfolio with portfolio_items that were discarded previously" do
+      let!(:second_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :discarded_at => 1.minute.ago, :tenant_id => tenant.id) }
+
+      before do
+        portfolio.discard
+      end
+
+      it "only undeletes the one that was discarded at the same time as the portfolio" do
+        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params
+
+        second_item.reload
+        expect(second_item.discarded?).to be_truthy
+      end
+    end
   end
 
   describe 'PATCH /portfolios/:portfolio_id' do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-169

Built off of #295, but for portfolios. That one needs to be merged first. 
Adds these two endpoints:

~`GET /portfolios/discarded` to list the discarded portfolios~
`GET /portfolios/{portfolio_id}/undelete` with params `{ :restore_key => 'someSha1Hash' }` to restore a deleted portfolio and all child portfolio items.

Also modifies the `DELETE /portfolios/{id}` method to return a 200 and a restore key so only the user who deleted the portfolio can restore it. 
