### PR TITLE
Modify as_json serializer to validate attributes exposed via openapi.json

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,12 +8,6 @@ class Order < ApplicationRecord
 
   before_create :set_defaults
 
-  AS_JSON_ATTRIBUTES = %w[id state owner created_at ordered_at completed_at].freeze
-
-  def as_json(_options = {})
-    super.slice(*AS_JSON_ATTRIBUTES)
-  end
-
   def set_defaults
     self.state = "Created"
   end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -15,13 +15,6 @@ class OrderItem < ApplicationRecord
   has_many :approval_requests, :dependent => :destroy
   before_create :set_defaults
 
-  AS_JSON_ATTRIBUTES = %w[id order_id service_plan_ref portfolio_item_id state service_parameters external_url
-                          provider_control_parameters external_ref insights_request_id created_at ordered_at completed_at updated_at].freeze
-
-  def as_json(_options = {})
-    super.slice(*AS_JSON_ATTRIBUTES)
-  end
-
   def set_defaults
     self.state = "Created"
 

--- a/app/models/progress_message.rb
+++ b/app/models/progress_message.rb
@@ -3,17 +3,11 @@ class ProgressMessage < ApplicationRecord
 
   after_initialize :set_defaults, unless: :persisted?
 
-  AS_JSON_ATTRIBUTES = %w(id level message received_at).freeze
-
   scope :by_owner, lambda {
     joins("INNER JOIN order_items ON (order_items.id = progress_messages.order_item_id::int)")
       .joins("INNER JOIN orders ON (orders.id = order_items.order_id::int)")
       .where("orders.owner = ?", ManageIQ::API::Common::Request.current.user.username)
   }
-
-  def as_json(_options = {})
-    super.slice(*AS_JSON_ATTRIBUTES)
-  end
 
   def set_defaults
     self.received_at = DateTime.now

--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -1,14 +1,29 @@
 module OpenApi
   module Serializer
     def as_json(arg = {})
-      return super unless kind_of?(ApplicationRecord)
-
-      super.tap do |hash|
-        hash.each_key do |attr_key|
-          hash[attr_key] = hash[attr_key].iso8601 if hash[attr_key].kind_of?(Time)
-          hash[attr_key] = hash[attr_key].to_s if attr_key.ends_with?("_id") || attr_key == "id"
-        end
+      previous = super
+      encrypted_columns_set = (self.class.try(:encrypted_columns) || []).to_set
+      encryption_filtered = previous.except(*encrypted_columns_set)
+      url = ManageIQ::API::Common::Request.current.instance_variable_get(:@original_url) || nil
+      base_path = url ? URI.parse(url).path : arg[:prefixes].first
+      version = api_version_from_prefix(base_path)
+      return encryption_filtered unless arg.key?(:prefixes) || version
+      schema  = Api::Docs[version].definitions[self.class.name]
+      attrs   = encryption_filtered.slice(*schema["properties"].keys)
+      schema["properties"].keys.each do |name|
+        next if attrs[name].nil?
+        attrs[name] = attrs[name].iso8601 if attrs[name].kind_of?(Time)
+        attrs[name] = attrs[name].to_s if name.ends_with?("_id") || name == "id"
+        attrs[name] = self.public_send(name) if !attrs.key?(name) && !encrypted_columns_set.include?(name)
       end
+      attrs.compact
+    end
+
+    def api_version_from_prefix(prefix)
+      return unless prefix
+      /\/?\w+\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ prefix
+      [major, minor].compact.join(".")
     end
   end
 end
+

--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -4,26 +4,39 @@ module OpenApi
       previous = super
       encrypted_columns_set = (self.class.try(:encrypted_columns) || []).to_set
       encryption_filtered = previous.except(*encrypted_columns_set)
+      version = version_from_path(arg)
+
+      return encryption_filtered unless arg.key?(:prefixes) || version
+
+      schema = Api::Docs[version].definitions[self.class.name]
+
+      filter(encryption_filtered.slice(*schema["properties"].keys), schema, encrypted_columns_set)
+    end
+
+    private
+
+    def version_from_path(arg)
       url = ManageIQ::API::Common::Request.current.instance_variable_get(:@original_url) || nil
       base_path = url ? URI.parse(url).path : arg[:prefixes].first
-      version = api_version_from_prefix(base_path)
-      return encryption_filtered unless arg.key?(:prefixes) || version
-      schema  = Api::Docs[version].definitions[self.class.name]
-      attrs   = encryption_filtered.slice(*schema["properties"].keys)
+      api_version_from_prefix(base_path)
+    end
+
+    def filter(attrs, schema, encrypted_columns_set)
       schema["properties"].keys.each do |name|
         next if attrs[name].nil?
+
         attrs[name] = attrs[name].iso8601 if attrs[name].kind_of?(Time)
         attrs[name] = attrs[name].to_s if name.ends_with?("_id") || name == "id"
-        attrs[name] = self.public_send(name) if !attrs.key?(name) && !encrypted_columns_set.include?(name)
+        attrs[name] = public_send(name) if !attrs.key?(name) && !encrypted_columns_set.include?(name)
       end
       attrs.compact
     end
 
     def api_version_from_prefix(prefix)
       return unless prefix
+
       /\/?\w+\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ prefix
       [major, minor].compact.join(".")
     end
   end
 end
-

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1452,6 +1452,18 @@
             "readOnly": true,
             "title": "Service Offering Icon Ref",
             "example": 20
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated at",
+            "readOnly": true
           }
         }
       },
@@ -1578,6 +1590,18 @@
             "type": "string",
             "title": "Owner",
             "example": "jdoe",
+            "readOnly": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created at",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated at",
             "readOnly": true
           }
         }

--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1447,12 +1447,6 @@
             "example": "jdoe",
             "readOnly": true
           },
-          "service_offering_icon_ref": {
-            "type": "string",
-            "readOnly": true,
-            "title": "Service Offering Icon Ref",
-            "example": 20
-          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -1591,6 +1585,12 @@
             "title": "Owner",
             "example": "jdoe",
             "readOnly": true
+          },
+          "service_offering_icon_ref": {
+            "type": "string",
+            "readOnly": true,
+            "title": "Service Offering Icon Ref",
+            "example": 20
           },
           "created_at": {
             "type": "string",

--- a/spec/lib/open_api/serializer_spec.rb
+++ b/spec/lib/open_api/serializer_spec.rb
@@ -6,7 +6,8 @@ describe OpenApi::Serializer do
 
   it "converts id columns to strings" do
     expect(portfolio_item.as_json(:prefixes => [request_path])).to include(
-      'id' => portfolio_item.id.to_s,
+      'id'   => portfolio_item.id.to_s,
+      'name' => portfolio_item.name
     )
   end
 
@@ -18,6 +19,6 @@ describe OpenApi::Serializer do
   end
 
   it 'excludes properties with nil values' do
-    expect(portfolio_item.as_json(:prefixes => [request_path]).keys).to_not include('archived_at')
+    expect(portfolio_item.as_json(:prefixes => [request_path]).keys).to_not include('discarded_at')
   end
 end

--- a/spec/lib/open_api/serializer_spec.rb
+++ b/spec/lib/open_api/serializer_spec.rb
@@ -1,22 +1,23 @@
 describe OpenApi::Serializer do
   let(:tenant) { create(:tenant) }
   let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => create(:portfolio, :tenant_id => tenant.id)) }
+  let(:request_path)   { "/api/v1.0/portfolio_items" }
+
 
   it "converts id columns to strings" do
-    expect(portfolio_item.as_json).to include(
-      'id'           => portfolio_item.id.to_s,
-      'portfolio_id' => portfolio_item.portfolio.id.to_s
+    expect(portfolio_item.as_json(:prefixes => [request_path])).to include(
+      'id' => portfolio_item.id.to_s,
     )
   end
 
   it "converts Time columns to iso8601" do
-    expect(portfolio_item.as_json).to include(
+    expect(portfolio_item.as_json(:prefixes => [request_path])).to include(
       'created_at' => portfolio_item.created_at.iso8601,
       'updated_at' => portfolio_item.updated_at.iso8601,
     )
   end
 
   it 'excludes properties with nil values' do
-    expect(portfolio_item.as_json.keys).to_not include('archived_at')
+    expect(portfolio_item.as_json(:prefixes => [request_path]).keys).to_not include('archived_at')
   end
 end

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -80,4 +80,20 @@ describe "OpenAPI stuff" do
       rand(1..10).times.collect { random_path_part }.join("/")
     end
   end
+
+  describe "Model serialization" do
+    context "v1.0" do
+      ActiveRecord::Base.connection.tables.each do |table|
+        next if %w[tenants schema_migrations ar_internal_metadata].include?(table)
+
+        model_name = table.singularize.camelize
+        model = model_name.constantize
+        Api::Docs["1.0"].definitions[model_name].properties.keys.each do |attr|
+          it "The JSON Schema #{attr} matches the #{table} attribute #{attr}" do
+            expect(model.new.attributes.include?(attr)).to be_truthy
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -81,7 +81,6 @@ describe "PortfolioItemRequests", :type => :request do
 
     it 'returns the portfolio_item which now points back to the portfolio' do
       expect(json.size).to eq 1
-      expect(json.first['portfolio_id']).to eq portfolio.id.to_s
     end
   end
 
@@ -180,7 +179,7 @@ describe "PortfolioItemRequests", :type => :request do
       post "#{api}/portfolio_items", :params => params, :headers => default_headers
       expect(response).to have_http_status(:ok)
       expect(json["id"]).to eq portfolio_item.id.to_s
-      expect(json["service_offering_ref"]).to eq service_offering_ref
+      expect(json["owner"]).to eq portfolio_item.owner
     end
   end
 

--- a/spec/requests/progress_message_spec.rb
+++ b/spec/requests/progress_message_spec.rb
@@ -17,7 +17,7 @@ describe "ProgressMessageRequests", :type => :request do
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)['data'].first['id']).to eq(progress_message.id.to_s)
+      expect(JSON.parse(response.body)['data'].first['message']).to eq(progress_message.message)
     end
 
     context "when the order item does not exist" do


### PR DESCRIPTION
Validate all attributes as exposed in `openapi.json`

Tests are all updated to no longer `expect` attributes not exposed
Added dates to `openapi.json` as were expected in a number of specs.

JIRA: https://projects.engineering.redhat.com/browse/SSP-95