### PR TITLE
Compliance with IPP-12

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,9 +9,13 @@ class ApplicationController < ActionController::API
 
   def with_current_request
     ManageIQ::API::Common::Request.with_request(request) do |current|
-      raise ManageIQ::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
+      if current.required_auth?
+        raise ManageIQ::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
 
-      ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
+        ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
+      else
+        ActsAsTenant.without_tenant { yield }
+      end
     end
   end
 


### PR DESCRIPTION
openapi.json should be accessible with and without authentication.
Our API fails because it always needs authentication.

Use changes made in PR https://github.com/ManageIQ/manageiq-api-common/pull/51

Specs already test this path

JIRA Story: https://projects.engineering.redhat.com/browse/SSP-467