### PR TITLE
Remove unreachable code from /portfolios/{id}/copy endpoint

### DIFF
--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -85,8 +85,6 @@ module Api
       def copy
         svc = Catalog::CopyPortfolio.new(portfolio_copy_params)
         render :json => svc.process.new_portfolio
-      rescue Catalog::InvalidParameter => e
-        json_response({ :errors => e.message }, :unprocessable_entity)
       end
 
       private


### PR DESCRIPTION
Noticed test coverage wasn't at 100% for the portfolios controller,
accidentally had some unreachable code from the portfolio_items 
controller that I copy/paste errored in. 

This removes the exception that is unreachable and gets test 
coverage back to 100%