### PR TITLE
Add order_id to the OrderItem openapi json spec

### DIFF
--- a/public/catalog/v1.0.0/openapi.json
+++ b/public/catalog/v1.0.0/openapi.json
@@ -1761,6 +1761,11 @@
             "description": "Current state of this order item.",
             "readOnly": true
           },
+          "order_id": {
+            "type": "string",
+            "title": "Order ID",
+            "description": "The Order that the OrderItem belongs to."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
We were missing this in the openapi spec, this should hopefully fix the UI order page. 