### PR TITLE
Add additional ReceivedMessage argument

### DIFF
--- a/spec/lib/approval_request_listener_spec.rb
+++ b/spec/lib/approval_request_listener_spec.rb
@@ -10,7 +10,7 @@ describe ApprovalRequestListener do
   let(:transition_instance) { instance_double(Catalog::ApprovalTransition) }
 
   describe "#subscribe_to_approval_updates" do
-    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, event, payload, nil, client) }
+    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, event, payload, nil, client, nil) }
     let(:order) { create(:order) }
     let!(:order_item) do
       create(:order_item,

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -1,7 +1,7 @@
 describe Catalog::UpdateOrderItem do
   describe "#process" do
     let(:client) { double(:client) }
-    let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client) }
+    let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client, nil) }
     let(:payload) { {"task_id" => "123", "status" => status, "state" => state, "context" => "payloadcontext"} }
     let!(:item) do
       ManageIQ::API::Common::Request.with_request(default_request) do


### PR DESCRIPTION
Added an additional argument to `ReceivedMessage` mocking. Makes tests green again.