### PR TITLE
Make /portfolio_items/{id}/copy endpoint change display name as well as name

### DIFF
--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -3,8 +3,8 @@ module Catalog
     attr_reader :new_portfolio_item
 
     def initialize(params)
-      @name = params[:portfolio_item_name]
       @portfolio_item = PortfolioItem.find(params[:portfolio_item_id])
+      @name = params[:portfolio_item_name] || @portfolio_item.display_name
 
       begin
         @to_portfolio = Portfolio.find(params[:portfolio_id] || @portfolio_item.portfolio_id)
@@ -24,17 +24,14 @@ module Catalog
 
     def make_copy
       @portfolio_item.dup.tap do |new_portfolio_item|
-        new_portfolio_item.name = @name || new_name
+        new_portfolio_item.name = new_name(@portfolio_item.name, :name)
+        new_portfolio_item.display_name = new_name(@name, :display_name)
         new_portfolio_item.save
       end
     end
 
-    def new_name
-      if @portfolio_item.portfolio_id == @to_portfolio.id
-        Catalog::NameAdjust.create_copy_name(@portfolio_item.name, @to_portfolio.portfolio_items.pluck(:name))
-      else
-        @portfolio_item.name
-      end
+    def new_name(name, field)
+      Catalog::NameAdjust.create_copy_name(name, @to_portfolio.portfolio_items.pluck(field))
     end
   end
 end

--- a/spec/factories/portfolio_items.rb
+++ b/spec/factories/portfolio_items.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :portfolio_item do
     sequence(:name)                 { |n| "PortfolioItem_name_#{n}" }
+    sequence(:display_name)         { |n| "PortfolioItem_display_name_#{n}" }
     sequence(:description)          { |n| "PortfolioItem_description_#{n}" }
     sequence(:service_offering_ref) { |n| (111 + n).to_s }
     sequence(:service_offering_source_ref) { |n| (222 + n).to_s }

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -307,7 +307,7 @@ describe "PortfolioItemRequests", :type => :request do
 
       it "returns the name specified" do
         copy_portfolio_item
-        expect(json["name"]).to eq params[:portfolio_item_name]
+        expect(json["display_name"]).to eq "Copy of " + params[:portfolio_item_name]
       end
     end
 
@@ -329,8 +329,8 @@ describe "PortfolioItemRequests", :type => :request do
         expect(json["workflow_ref"]).to eq portfolio_item.workflow_ref
       end
 
-      it "does not modify the name" do
-        expect(json["name"]).to eq portfolio_item.name
+      it "prefixes the name with Copy of" do
+        expect(json["name"]).to match(/^Copy of.*/)
       end
     end
 

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -354,7 +354,7 @@ describe 'Portfolios API' do
       it "copies the portfolio item over" do
         item = PortfolioItem.find(Portfolio.find(json["id"]).portfolio_items.first.id)
 
-        expect(item.name).to eq portfolio_item.name
+        expect(item.name).to eq "Copy of " + portfolio_item.name
         expect(item.description).to eq portfolio_item.description
         expect(item.owner).to eq portfolio_item.owner
       end

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -30,7 +30,7 @@ describe Catalog::CopyPortfolioItem do
 
         expect(new.description).to eq portfolio_item.description
         expect(new.owner).to eq portfolio_item.owner
-        expect(new.name).to eq portfolio_item.name
+        expect(new.name).to match(/^Copy of.*/)
       end
     end
 

--- a/spec/services/catalog/copy_portfolio_spec.rb
+++ b/spec/services/catalog/copy_portfolio_spec.rb
@@ -26,7 +26,7 @@ describe Catalog::CopyPortfolio do
       it "copies over the portfolio_items fields" do
         items = new_portfolio.portfolio_items
 
-        expect(items.collect(&:name)).to match_array([portfolio_item1.name, portfolio_item2.name])
+        expect(items.collect(&:name)).to match_array(["Copy of #{portfolio_item1.name}", "Copy of #{portfolio_item2.name}"])
         expect(items.collect(&:description)).to match_array([portfolio_item1.description, portfolio_item2.description])
         expect(items.collect(&:owner)).to match_array([portfolio_item1.owner, portfolio_item2.owner])
       end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-511

This PR is correlated with changes in #314, basically this PR changes a couple things related to copy behavior

- always run the `Catalog::NameAdjust` workflow on the name which is passed in, just in case.
- run ^^ workflow on both the name and the display name, since we're getting the display name passed in.