### PR TITLE
[WIP] Specs for common graphql use cases

### DIFF
--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -8,11 +8,21 @@ RSpec.describe("v1.0 - GraphQL") do
   let(:tenant) { create(:tenant) }
   let!(:portfolio_a) { create(:portfolio, :tenant_id => tenant.id, :description => 'test a desc', :name => "test_a", :owner => "234") }
   let!(:portfolio_b) { create(:portfolio, :tenant_id => tenant.id, :description => 'test b desc', :name => "test_b", :owner => "123") }
+  let!(:portfolio_c) { create(:portfolio, :tenant_id => tenant.id, :description => 'test c desc', :name => "test_c", :owner => "321") }
 
-  let(:graphql_portfolio_query) { { "query" => "{ portfolios { id name } }" } }
+  let!(:portfolio_item_a) { create(:portfolio_item, :portfolio => portfolio_a, :name => 'portfolio item a') }
+  let!(:order_a) { create(:order, :tenant_id => tenant.id) }
+  let!(:order_item) { create(:order_item, :order_id => order_a.id, :portfolio_item_id => portfolio_item_a.id, :tenant_id => tenant.id) }
+
+  let(:graphql_portfolio_query) { { "query" => "{ portfolios {  name id } }" } }
 
   def result_portfolios(response_body)
     JSON.parse(response_body).fetch_path("data", "portfolios")
+  end
+
+  # if graphql query fails it does not return 5xx or 4xx it adds "errors key" to the response object response.status it not enough to check sucessfull response
+  def positive_graphql_response(response)
+    response.parsed_body["data"]
   end
 
   context "different graphql queries" do
@@ -22,14 +32,101 @@ RSpec.describe("v1.0 - GraphQL") do
 
     it "querying portfolios return portfolio ids" do
       expect(response.status).to eq(200)
-      result_portfolio_ids = result_portfolios(response.body).collect { |pf| pf["id"].to_i }
-      expect(result_portfolio_ids).to match_array([portfolio_a.id, portfolio_b.id])
+      expect(positive_graphql_response(response)).to be_truthy
+      result_portfolio_ids = result_portfolios(response.body).collect { |portfolio| portfolio.fetch_path("id").to_i }
+      expect(result_portfolio_ids).to match_array([portfolio_a.id, portfolio_b.id, portfolio_c.id])
     end
-
+    
     it "querying portfolios return portfolio names" do
       expect(response.status).to eq(200)
-      result_portfolio_names = result_portfolios(response.body).collect { |pf| pf["name"] }
-      expect(result_portfolio_names).to match_array([portfolio_a.name, portfolio_b.name])
+      expect(positive_graphql_response(response)).to be_truthy
+      result_portfolio_names = result_portfolios(response.body).collect { |portfolio| portfolio.fetch_path("name") }
+      expect(result_portfolio_names).to match_array([portfolio_a.name, portfolio_b.name, portfolio_c.name])
+    end
+  end
+  
+  context "filtering queries" do
+    it "portfolios using attribute should return porfolio names and ids" do
+      # direct attributes filtering does not work
+      post(
+        "/api/v1.0/graphql",
+        :headers => default_headers,
+        :params  => { "query" => "{ portfolios(name: \"#{portfolio_a.name}\") { id name } }" }
+      )
+      result = result_portfolios(response.body)
+      expect(response.status).to eq(200)
+      expect(positive_graphql_response(response)).to be_truthy
+      expect(result.length).to be(1)
+      expect(result[0]).to include("node" => { "id" => portfolio_a.id.to_s, "name" => portfolio_a.name })
+    end
+
+    it "portfolios using filter parameters should return porfolio names and ids" do
+      # direct attributes filtering does not work
+      post(
+        "/api/v1.0/graphql",
+        :headers => default_headers,
+        :params  => { "query" => "{ portfolios(filter: {name: \"#{portfolio_a.name}\"}) { id name } }" }
+      )
+      result = result_portfolios(response.body)
+      expect(response.status).to eq(200)
+      expect(positive_graphql_response(response)).to be_truthy
+      expect(result.length).to be(1)
+      expect(result[0]).to include("id" => portfolio_a.id.to_s, "name" => portfolio_a.name)
+    end
+
+    it "by multiple ids in via direct attributes and return list of portfolios" do
+      # direct attributes filtering does not work
+      # using ID should work but returns an error with invalid ID type: Argument 'id' on Field 'portfolios' has an invalid value. Expected type 'ID'.
+      post(
+        "/api/v1.0/graphql",
+        :headers => default_headers,
+        :params  => { "query" => "{ portfolios(id: [\"#{portfolio_a.id.to_s}\", \"#{portfolio_b.id.to_s}\"]) { id name } }" }
+      )
+      result = result_portfolios(response.body)
+      expect(response.status).to eq(200)
+      expect(positive_graphql_response(response)).to be_truthy
+      expect(result.length).to be(2)
+      expect(result).to include({"node" => { "id" => portfolio_a.id.to_s, "name" => portfolio_a.name }}, {"node" => { "id" => portfolio_b.id.to_s, "name" => portfolio_b.name }})
+    end
+
+    it "by multiple ids in via filter parameters attributes and return list of portfolios" do
+      post(
+        "/api/v1.0/graphql",
+        :headers => default_headers,
+        :params  => { "query" => "{ portfolios(filter: {id: [\"#{portfolio_a.id}\", \"#{portfolio_b.id}\"]}) { id name } }" }
+      )
+      result = result_portfolios(response.body)
+      expect(response.status).to eq(200)
+      expect(positive_graphql_response(response)).to be_truthy
+      expect(result.length).to be(2)
+      expect(result).to include(
+        {"id" => portfolio_a.id.to_s, "name" => portfolio_a.name },
+        { "id" => portfolio_b.id.to_s, "name" => portfolio_b.name }
+      )
+    end
+  end
+
+  context "pagination queries" do
+    # limit offset pagination should work after relay based spec will be removed
+    let(:graphql_portfolio_paginated_query) { { "query" => "{ portfolios(limit: 1 offset: 1) { id name } }" } }
+
+    it "paginate portfolios" do
+      post("/api/v1.0/graphql", :headers => default_headers, :params => graphql_portfolio_paginated_query)
+      result = result_portfolios(response.body)
+      expect(response.status).to eq(200)
+      expect(positive_graphql_response(response)).to be_truthy
+      expect(result.length).to eq(1)
+      expect(result).to include({ "id" => portfolio_b.id.to_s, "name" => portfolio_b.name })
+    end
+  end
+
+  context "association queries" do
+    let(:graphql_portfolio_association_query) { { "query" => "{ portfolios { id, portfolioItems { id } } }" } }
+
+    it "should add order items to portfolios" do
+      post("/api/v1.0/graphql", :headers => default_headers, :params => graphql_portfolio_association_query)
+      expect(response.status).to eq(200)
+      expect(positive_graphql_response(response)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
cc @abellotti

I'll be adding test for common graphql query use cases.

Currently there is a number of issues with certain queries. I did not find many docs or examples for our implementation so it is very likely that i am trying to use different query syntax so let me know if issues listed bellow are not issues at all. (i am aware that the `edges`, `node` syntax will be gone soon)

I am using portfolios as a reference entity because it supports most of the features like filtering, pagination, etc.

I've also generated a simple docs from graphql schema to help me navigate through the schema:
http://catalog-graphql-docs.surge.sh

## Associations 
### List portfolio items for each portfolio
#### Issues
- i was not able to find any association between objects
- no sub collections are listed in the docs: http://catalog-graphql-docs.surge.sh/portfolio.doc.html
#### Query
```
{ portfolios { edges { node { name portfolio_item { name } } } } } // portfolio_item don't know what identifier i should use here
```
#### Response
```
{"errors"=>
  [{"message"=>"Field 'portfolio_items' doesn't exist on type 'Portfolio'",
    "locations"=>[{"line"=>1, "column"=>36}],
    "path"=>["query", "portfolios", "edges", "node", "portfolio_items"],
    "extensions"=>{"code"=>"undefinedField", "typeName"=>"Portfolio", "fieldName"=>"portfolio_items"}}]}
```
#### Expected result
- List of portfolios with associated portfolio items

## Pagination
### Paginate using limit and offset
#### Issues
- pagination does not work
#### Query
```
{ portfolios(limit: 1 offset: 1) { edges { node { id name } } } }
```
#### Response
```ruby
{"errors"=>
  [{"message"=>"Field 'portfolios' doesn't accept argument 'limit'",
    "locations"=>[{"line"=>1, "column"=>14}],
    "path"=>["query", "portfolios", "limit"],
    "extensions"=>{"code"=>"argumentNotAccepted", "name"=>"portfolios", "typeName"=>"Field", "argumentName"=>"limit"}},
   {"message"=>"Field 'portfolios' doesn't accept argument 'offset'",
    "locations"=>[{"line"=>1, "column"=>23}],
    "path"=>["query", "portfolios", "offset"],
    "extensions"=>{"code"=>"argumentNotAccepted", "name"=>"portfolios", "typeName"=>"Field", "argumentName"=>"offset"}}]}
```
#### Expected result
- paginated list of portfolios


## Filtering
### Filter by single value
#### Issues
- can only filter by portfolio ID if we use classic attributes filtering
- extended request allows me to filter id, name etc.
#### Query:
```
{ portfolios(name: "test_a") { edges { node { id name } } } }
```

#### Response
```ruby
{"errors"=>
  [{"message"=>"Field 'portfolios' doesn't accept argument 'name'",
    "locations"=>[{"line"=>1, "column"=>14}],
    "path"=>["query", "portfolios", "name"],
    "extensions"=>{"code"=>"argumentNotAccepted", "name"=>"portfolios", "typeName"=>"Field", "argumentName"=>"name"}}]}
```
#### Expected result
Return portfolio with correct name

#### Notes
- works if we use extended filter syntax:
```
{ portfolios(filter: {name: "test_a"}) { edges { node { id name } } } }
```

### Filter by multiple values value
#### Issue
- filtering by id throws invalid type exception. Cannot use number or string only type ID. That is not usable.
- filtering by other attributes is not possible with simple filter param
- can filter only by nested params
#### Query
```
{ portfolios(name:["test_a", "test_b"]) { edges { node { id name } } } } // cant' filter by name
{ portfolios(id: [\"#{portfolio_a.id.to_s}\", \"#{portfolio_b.id.to_s}\"]) { edges { node { id name } } } } // tried both number and string
{ portfolios(filter: { id: [\"#{portfolio_a.id}\", \"#{portfolio_b.id}\"] }) { edges { node { id name } } } } // this works
```
#### Response
```ruby
{"errors"=>
  [{"message"=>"Argument 'id' on Field 'portfolios' has an invalid value. Expected type 'ID'.",
    "locations"=>[{"line"=>1, "column"=>3}],
    "path"=>["query", "portfolios", "id"],
    "extensions"=>{"code"=>"argumentLiteralsIncompatible", "typeName"=>"Field", "argumentName"=>"id"}}]}

```
#### Expected result
List of entities matching filter params