### PR TITLE
Add /icon endpoint for manipulating custom icons

### DIFF
--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -24,8 +24,8 @@ module Api
         render :json => icon
       end
 
-      def show_icon
-        icon = find_icon
+      def raw_icon
+        icon = find_icon(params.permit(:icon_id, :portfolio_item_id))
         send_data(icon.data,
                   :type        => MimeMagic.by_magic(icon.data).type,
                   :disposition => 'inline')
@@ -42,8 +42,8 @@ module Api
         params.permit(:data, :source_ref, :source_id, :portfolio_item_id)
       end
 
-      def find_icon
-        params[:icon_id].present? ? Icon.find(params[:icon_id]) : Icon.find_by!(:portfolio_item_id => params[:portfolio_item_id])
+      def find_icon(ids)
+        ids[:icon_id].present? ? Icon.find(ids[:icon_id]) : Icon.find_by!(:portfolio_item_id => ids[:portfolio_item_id])
       end
     end
   end

--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -4,15 +4,46 @@ module Api
       include Api::V1x0::Mixins::IndexMixin
 
       def show
-        portfolio_item = PortfolioItem.find_by!(:id => params.require(:portfolio_item_id))
-        raise ActiveRecord::RecordNotFound, "Icon not present on Portfolio Item" if portfolio_item.service_offering_icon_ref.nil?
+        render :json => Icon.find(params.require(:id))
+      end
 
-        so = ServiceOffering::Icons.new(portfolio_item.service_offering_icon_ref)
-        icon = so.process.icon
+      def create
+        icon = Icon.create!(icon_params)
+        render :json => icon
+      end
 
+      def destroy
+        Icon.find(params.require(:id)).destroy
+        head :no_content
+      end
+
+      def update
+        icon = Icon.find(params.require(:id))
+        icon.update!(icon_patch_params)
+
+        render :json => icon
+      end
+
+      def show_icon
+        icon = find_icon
         send_data(icon.data,
                   :type        => MimeMagic.by_magic(icon.data).type,
                   :disposition => 'inline')
+      end
+
+      private
+
+      def icon_params
+        params.require(:data)
+        icon_patch_params
+      end
+
+      def icon_patch_params
+        params.permit(:data, :source_ref, :source_id, :portfolio_item_id)
+      end
+
+      def find_icon
+        params[:icon_id].present? ? Icon.find(params[:icon_id]) : Icon.find_by!(:portfolio_item_id => params[:portfolio_item_id])
       end
     end
   end

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -58,6 +58,12 @@ module Api
         render :json => { :next_name => svc.process.next_name }
       end
 
+      def add_icon_to_portfolio_item
+        icon = Icon.find(params.require(:icon_id))
+        portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
+        render :json => portfolio_item.add_icon(icon)
+      end
+
       private
 
       def portfolio_item_params

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -1,0 +1,6 @@
+class Icon < ApplicationRecord
+  acts_as_tenant(:tenant)
+
+  belongs_to :portfolio_item
+  validates :data, :presence => true
+end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -5,8 +5,13 @@ class PortfolioItem < ApplicationRecord
 
   default_scope -> { kept }
 
+  has_one :icon, :dependent => :destroy
   belongs_to :portfolio
   validates :service_offering_ref, :presence => true
+
+  def add_icon(icon)
+    self.icon = icon
+  end
 
   def resolved_workflow_refs
     # TODO: Add lookup to platform workflow ref

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -16,6 +16,7 @@ module ServiceOffering
 
       # Get the fields that we're going to pull over
       @item = PortfolioItem.create!(generate_attributes)
+      @item.icon = create_icon(@service_offering.service_offering_icon_id)
       self
     rescue StandardError => e
       Rails.logger.error("Service Offering Ref: #{@params[:service_offering_ref]} #{e.message}")
@@ -40,11 +41,19 @@ module ServiceOffering
     # If certain fields are empty populate them from the other fields that we do have.
     def populate_missing_fields
       @params[:service_offering_source_ref] = @service_offering.source_id
-      @params[:service_offering_icon_ref] = @service_offering.service_offering_icon_id
       # Fill up empty fields if they're empty with fields we already have, this is really easy with the ||= and subsequent || operators
       @params[:long_description] ||= @params[:description] || @params[:display_name]
       @params[:display_name] ||= @params[:name]
       @params
+    end
+
+    def create_icon(icon_id)
+      service_offering_icon = TopologicalInventory.call { |topo| topo.show_service_offering_icon(icon_id) }
+      Icon.create!(
+        :data       => service_offering_icon.data,
+        :source_ref => service_offering_icon.source_ref,
+        :source_id  => service_offering_icon.source_id
+      )
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,13 +48,13 @@ Rails.application.routes.draw do
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]
         resources :service_plans,               :only => [:index]
-        get :icon, :to => 'icons#show_icon'
+        get :icon, :to => 'icons#raw_icon'
         get :next_name, :action => 'next_name', :controller => 'portfolio_items'
         post :copy, :action => 'copy', :controller => 'portfolio_items'
         post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
       end
       resources :icons, :only => [:create, :destroy, :show, :update] do
-        get :icon_data, :action => 'show_icon', :controller => 'icons'
+        get :icon_data, :to => 'icons#raw_icon'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,13 +44,17 @@ Rails.application.routes.draw do
         post :copy, :action => 'copy', :controller => 'portfolios'
         post :undelete, :action => 'restore', :controller => 'portfolios'
       end
+      post '/portfolio_items/:portfolio_item_id/icon', :to => 'portfolio_items#add_icon_to_portfolio_item'
       resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]
         resources :service_plans,               :only => [:index]
-        get :icon, :action => 'show', :controller => 'icons'
+        get :icon, :to => 'icons#show_icon'
         get :next_name, :action => 'next_name', :controller => 'portfolio_items'
         post :copy, :action => 'copy', :controller => 'portfolio_items'
         post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
+      end
+      resources :icons, :only => [:create, :destroy, :show, :update] do
+        get :icon_data, :action => 'show_icon', :controller => 'icons'
       end
     end
   end

--- a/db/migrate/20190625173111_create_icons.rb
+++ b/db/migrate/20190625173111_create_icons.rb
@@ -1,0 +1,16 @@
+class CreateIcons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :icons do |t|
+      t.string :data
+      t.string :source_ref
+      t.string :source_id
+      t.bigint :portfolio_item_id
+      t.bigint :tenant_id
+      t.index :tenant_id
+
+      t.timestamps
+    end
+
+    remove_column :portfolio_items, :service_offering_icon_ref, :string
+  end
+end

--- a/db/migrate/20190625173111_create_icons.rb
+++ b/db/migrate/20190625173111_create_icons.rb
@@ -1,5 +1,5 @@
 class CreateIcons < ActiveRecord::Migration[5.2]
-  def change
+  def up
     create_table :icons do |t|
       t.string :data
       t.string :source_ref
@@ -11,6 +11,76 @@ class CreateIcons < ActiveRecord::Migration[5.2]
       t.timestamps
     end
 
+    PortfolioItem.all.each do |item|
+      ManageIQ::API::Common::Request.with_request(dummy_request) do
+        icon = TopologicalInventory.call { |api| api.show_service_offering_icon(item.service_offering_icon_ref) }
+
+        Icon.create!(
+          :data              => icon.data,
+          :source_ref        => icon.source_ref,
+          :source_id         => icon.source_id,
+          :portfolio_item_id => item.id
+        )
+      end
+    end
+
     remove_column :portfolio_items, :service_offering_icon_ref, :string
+  end
+
+  def down
+    drop_table :icons
+    add_column :portfolio_items, :service_offering_icon_ref, :string
+  end
+
+  private
+
+  def dummy_request
+    {
+      :headers      => {
+        'x-rh-identity'            => encoded_user_hash,
+        'x-rh-insights-request-id' => "rails_migration"
+      },
+      :original_url => "catalog-api"
+    }
+  end
+
+  def encoded_user_hash
+    user_hash = {
+      "entitlements" => {
+        "hybrid_cloud"     => {
+          "is_entitled" => true
+        },
+        "insights"         => {
+          "is_entitled" => true
+        },
+        "openshift"        => {
+          "is_entitled" => true
+        },
+        "smart_management" => {
+          "is_entitled" => true
+        }
+      },
+      "identity"     => {
+        "account_number" => "0369233",
+        "type"           => "User",
+        "user"           => {
+          "username"     => "jdoe",
+          "email"        => "jdoe@acme.com",
+          "first_name"   => "John",
+          "last_name"    => "Doe",
+          "is_active"    => true,
+          "is_org_admin" => true, # set the org_admin flag since we're going to need to access everything
+          "is_internal"  => false,
+          "locale"       => "en_US"
+        },
+        "internal"       => {
+          "org_id"    => "3340851",
+          "auth_type" => "basic-auth",
+          "auth_time" => 6300
+        }
+      }
+    }
+
+    Base64.strict_encode64(user_hash.to_json)
   end
 end

--- a/db/migrate/20190625173111_create_icons.rb
+++ b/db/migrate/20190625173111_create_icons.rb
@@ -11,20 +11,16 @@ class CreateIcons < ActiveRecord::Migration[5.2]
       t.timestamps
     end
 
-    PortfolioItem.all.each do |item|
-      ManageIQ::API::Common::Request.with_request(dummy_request) do
-        icon = TopologicalInventory.call { |api| api.show_service_offering_icon(item.service_offering_icon_ref) }
+    puts <<~EOMESSAGE
+      XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      After this migration, one needs to run
+      `rake db:migrate:icons EMAIL=my_real_email@redhat.com`
+      to actually move all of the icon references to the new table.
 
-        Icon.create!(
-          :data              => icon.data,
-          :source_ref        => icon.source_ref,
-          :source_id         => icon.source_id,
-          :portfolio_item_id => item.id
-        )
-      end
-    end
-
-    remove_column :portfolio_items, :service_offering_icon_ref, :string
+      Until this is done, the icon endpoints will be broken since the
+      references aren't correct.
+      XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    EOMESSAGE
   end
 
   def down
@@ -32,55 +28,9 @@ class CreateIcons < ActiveRecord::Migration[5.2]
     add_column :portfolio_items, :service_offering_icon_ref, :string
   end
 
-  private
-
-  def dummy_request
-    {
-      :headers      => {
-        'x-rh-identity'            => encoded_user_hash,
-        'x-rh-insights-request-id' => "rails_migration"
-      },
-      :original_url => "catalog-api"
-    }
-  end
-
-  def encoded_user_hash
-    user_hash = {
-      "entitlements" => {
-        "hybrid_cloud"     => {
-          "is_entitled" => true
-        },
-        "insights"         => {
-          "is_entitled" => true
-        },
-        "openshift"        => {
-          "is_entitled" => true
-        },
-        "smart_management" => {
-          "is_entitled" => true
-        }
-      },
-      "identity"     => {
-        "account_number" => "0369233",
-        "type"           => "User",
-        "user"           => {
-          "username"     => "jdoe",
-          "email"        => "jdoe@acme.com",
-          "first_name"   => "John",
-          "last_name"    => "Doe",
-          "is_active"    => true,
-          "is_org_admin" => true, # set the org_admin flag since we're going to need to access everything
-          "is_internal"  => false,
-          "locale"       => "en_US"
-        },
-        "internal"       => {
-          "org_id"    => "3340851",
-          "auth_type" => "basic-auth",
-          "auth_time" => 6300
-        }
-      }
-    }
-
-    Base64.strict_encode64(user_hash.to_json)
+  # Only gets called from `rake icons:migrate`, which needs to be run after this migration to move all of the
+  # icons from a reference on PortfolioItem to the new Icon model
+  def finalize_migration
+    remove_column :portfolio_items, :service_offering_icon_ref, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_163638) do
+ActiveRecord::Schema.define(version: 2019_06_25_173111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 2019_05_01_163638) do
     t.integer "state", default: 0
     t.bigint "tenant_id"
     t.index ["tenant_id"], name: "index_approval_requests_on_tenant_id"
+  end
+
+  create_table "icons", force: :cascade do |t|
+    t.string "data"
+    t.string "source_ref"
+    t.string "source_id"
+    t.bigint "portfolio_item_id"
+    t.bigint "tenant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tenant_id"], name: "index_icons_on_tenant_id"
   end
 
   create_table "order_items", force: :cascade do |t|
@@ -80,7 +91,6 @@ ActiveRecord::Schema.define(version: 2019_05_01_163638) do
     t.datetime "discarded_at"
     t.string "workflow_ref"
     t.string "owner"
-    t.string "service_offering_icon_ref"
     t.index ["discarded_at"], name: "index_portfolio_items_on_discarded_at"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end

--- a/lib/tasks/migrate_icons.rake
+++ b/lib/tasks/migrate_icons.rake
@@ -1,0 +1,85 @@
+require 'rake'
+
+namespace :db do
+  namespace :migrate do
+    desc "Migrate Icon data from portfolio_items.service_offering_icon_ref => Icons. Requires a valid EMAIL to do the migration"
+    task :icons => :environment do
+      if ENV["EMAIL"].blank?
+        puts "EMAIL is required to run this migration."
+        exit 1
+      end
+
+      PortfolioItem.all.each do |item|
+        next if item.service_offering_icon_ref.nil?
+
+        @acct = item.tenant.external_tenant
+        ManageIQ::API::Common::Request.with_request(dummy_request) do
+          icon = TopologicalInventory.call { |api| api.show_service_offering_icon(item.service_offering_icon_ref) }
+
+          Icon.create!(
+            :data              => icon.data,
+            :source_ref        => icon.source_ref,
+            :source_id         => icon.source_id,
+            :portfolio_item_id => item.id
+          )
+        end
+      end
+
+      # now that all of the icons are moved over, remove the now useless column.
+      require Rails.root.join("db", "migrate", "20190625173111_create_icons.rb")
+      CreateIcons.new.finalize_migration
+    end
+
+    private
+
+    def dummy_request
+      {
+        :headers      => {
+          'x-rh-identity'            => encoded_user_hash,
+          'x-rh-insights-request-id' => "rails_migration"
+        },
+        :original_url => "catalog-api"
+      }
+    end
+
+    def encoded_user_hash
+      user_hash = {
+        "entitlements" => {
+          "hybrid_cloud"     => {
+            "is_entitled" => true
+          },
+          "insights"         => {
+            "is_entitled" => true
+          },
+          "openshift"        => {
+            "is_entitled" => true
+          },
+          "smart_management" => {
+            "is_entitled" => true
+          }
+        },
+        "identity"     => {
+          "account_number" => @acct,
+          "type"           => "User",
+          "user"           => {
+            "username"     => "jdoe",
+            "email"        => ENV["EMAIL"],
+            "first_name"   => "Catalog",
+            "last_name"    => "API",
+            "is_active"    => true,
+            "is_org_admin" => true, # set the org_admin flag since we're going to need to access everything
+            "is_internal"  => false,
+            "locale"       => "en_US"
+          },
+          "internal"       => {
+            "org_id"    => "3340851",
+            "auth_type" => "basic-auth",
+            "auth_time" => 6300
+          }
+        }
+      }
+
+      Base64.strict_encode64(user_hash.to_json)
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1340,9 +1340,9 @@
         "tags": [
           "PortfolioItem"
         ],
-        "summary": "Fetches the specified portfolio item's icon information",
-        "operationId": "listServiceOfferingIcon",
-        "description": "Fetch the specified portfolio item's icon information.",
+        "summary": "Fetches the specified portfolio item's icon image",
+        "operationId": "showPortfolioItemIcon",
+        "description": "Fetch the specified portfolio item's icon image.",
         "parameters": [
           {
             "$ref": "#/components/parameters/PortfolioItemID"
@@ -1352,10 +1352,8 @@
           "200": {
             "description": "Portfolio Item Icon",
             "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceOfferingIcon"
-                }
+              "image/svg+xml": {
+                "example": "<svg rel=\"stylesheet\">thing</svg>"
               }
             }
           },
@@ -1371,6 +1369,50 @@
           "500": {
             "description": "Could not access the Topology Service"
           }
+        }
+      },
+      "post": {
+        "tags": [
+          "PortfolioItem"
+        ],
+        "summary": "Add an Icon to a Portfolio Item",
+        "operationId": "addIconToPortfolioItem",
+        "description": "Add an Icon to a Portfolio Item",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PortfolioItemID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The added Icon",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Icon not found"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddIcon"
+              }
+            }
+          },
+          "required": true
         }
       }
     },
@@ -1423,6 +1465,177 @@
             }
           },
           "required": false
+        }
+      }
+    },
+    "/icons": {
+      "post": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Create an Icon",
+        "description": "Creates an Icon from the specified parameters",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Icon"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The newly created Icon",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/icons/{id}": {
+      "get": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Fetch an Icon by ID",
+        "description": "Fetch an Icon by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Icon matching the Icon ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Icon not found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Edit an existing Icon",
+        "description": "Edits Icon specified by the given ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Icon"
+              }
+            }
+          },
+          "description": "Parameters needed to update an Icon",
+          "required": true
+        },
+        "operationId": "updateIcon",
+        "responses": {
+          "200": {
+            "description": "Return the updated Icon object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Icon was not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Delete an existing Icon",
+        "operationId": "destroyIcon",
+        "description": "Deletes the icon based on the icon ID passed\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Icon deleted."
+          },
+          "404": {
+            "description": "Icon not found."
+          }
+        }
+      }
+    },
+    "/icons/{id}/icon_data": {
+      "get": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Fetches the specified icon's image",
+        "operationId": "showIconData",
+        "description": "Fetch the specified portfolio item's icon image.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Item Icon",
+            "content": {
+              "image/svg+xml": {
+                "example": "<svg rel=\"stylesheet\">thing</svg>"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Icon Not Found/Not Present on Portfolio Item"
+          }
         }
       }
     },
@@ -1733,6 +1946,17 @@
           }
         }
       },
+      "AddIcon": {
+        "type": "object",
+        "properties": {
+          "icon_id": {
+            "type": "string",
+            "title": "Icon Id",
+            "example": "100",
+            "description": "This is the ID of the icon object."
+          }
+        }
+      },
       "PortfolioItem": {
         "type": "object",
         "properties": {
@@ -1807,12 +2031,6 @@
             "title": "Owner",
             "example": "jdoe",
             "readOnly": true
-          },
-          "service_offering_icon_ref": {
-            "type": "string",
-            "readOnly": true,
-            "title": "Service Offering Icon Ref",
-            "example": 20
           },
           "service_offering_source_ref": {
             "type": "string",
@@ -2031,7 +2249,7 @@
           }
         }
       },
-      "ServiceOfferingIcon": {
+      "Icon": {
         "type": "object",
         "properties": {
           "id": {
@@ -2050,6 +2268,12 @@
             "type": "string",
             "title": "Source Ref",
             "description": "Stores the Source Ref for this icon",
+            "readOnly": true
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source ID",
+            "description": "The source ID for this icon",
             "readOnly": true
           }
         }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1579,7 +1579,7 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "404": {
-            "description": "The Icon was not found"
+            "description": "Icon not found."
           }
         }
       },
@@ -1634,7 +1634,7 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "404": {
-            "description": "Icon Not Found/Not Present on Portfolio Item"
+            "description": "Icon Not Found."
           }
         }
       }

--- a/spec/factories/icon.rb
+++ b/spec/factories/icon.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :icon do
+    sequence(:source_ref) { |n| "source_ref_#{n}" }
+    sequence(:source_id)  { |n| "source_id_#{n}" }
+    sequence(:data)       { |n| "<svg real=\"stylesheet\">thing#{n}</svg>" }
+  end
+end

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -1,65 +1,93 @@
 describe "IconsRequests", :type => :request do
-  let(:icon_id) { 1 }
-  let(:api_instance) { double }
-  let(:topological_inventory) do
-    class_double("TopologicalInventory")
-      .as_stubbed_const(:transfer_nested_constants => true)
-  end
-
   let(:tenant) { create(:tenant) }
-  let(:portfolio_item) do
-    create(:portfolio_item, :service_offering_icon_ref => icon_id,
-                            :tenant_id                 => tenant.id)
-  end
-
-  let(:topology_service_offering_icon) do
-    TopologicalInventoryApiClient::ServiceOfferingIcon.new(
-      :id         => icon_id.to_s,
-      :source_ref => "src",
-      :data       => "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><defs><style>.cls-1{fill:#d71e00}.cls-2{fill:#c21a00}.cls-3{fill:#fff}.cls-4{fill:#eaeaea}</style></defs><title>Logo</title><g id=\"Layer_1\" data-name=\"Layer 1\"><circle class=\"cls-1\" cx=\"50\" cy=\"50\" r=\"50\" transform=\"rotate(-45 50 50)\"/><path class=\"cls-2\" d=\"M85.36 14.64a50 50 0 0 1-70.72 70.72z\"/><path d=\"M31 31.36a1.94 1.94 0 0 1-3.62-.89.43.43 0 0 1 .53-.44 3.32 3.32 0 0 0 2.81.7.43.43 0 0 1 .28.63z\"/><path class=\"cls-3\" d=\"M77.63 44.76C77.12 41.34 73 21 66.32 21c-2.44 0-4.59 3.35-6 6.88-.44 1.06-1.23 1.08-1.63 0-1.45-3.72-2.81-6.88-5.41-6.88-9.94 0-5.44 24.18-14.28 24.18-4.57 0-5.37-10.59-5.5-14.72 2.19.65 3.3-1 3.55-2.61a.63.63 0 0 0-.48-.72 3.36 3.36 0 0 0-3 .89h-6.26a1 1 0 0 0-.68.28l-.53.53h-3.89a.54.54 0 0 0-.38.16l-3.95 3.95a.54.54 0 0 0 .38.91h11.45c.6 6.26 1.75 22 16.42 17.19l-.32 5-1.44 22.42a1 1 0 0 0 1 1h4.9a1 1 0 0 0 1-1l-.61-23.33-.15-5.81c6-2.78 9-5.66 16.19-6.75-1.59 2.62-2.05 6.87-2.06 8-.06 6 2.55 8.74 5 13.22L63.73 78a1 1 0 0 0 .89 1.32h4.64a1 1 0 0 0 .93-.74L74 62.6c-4.83-7.43 1.83-15.31 3.41-17a1 1 0 0 0 .22-.84zM31 31.36a1.94 1.94 0 0 1-3.62-.89.43.43 0 0 1 .53-.44 3.32 3.32 0 0 0 2.81.7.43.43 0 0 1 .28.63z\"/><path class=\"cls-4\" d=\"M46.13 51.07c-14.67 4.85-15.82-10.93-16.42-17.19H18.65l2.1 2.12a1 1 0 0 0 .68.28h6c0 5.8 1.13 20.2 14 20.2a31.34 31.34 0 0 0 4.42-.35zM50.41 49.36l.15 5.81a108.2 108.2 0 0 0 14-4.54 19.79 19.79 0 0 1 2.06-8c-7.16 1.07-10.18 3.95-16.21 6.73z\"/></g></svg>"
-    )
-  end
-
-  let(:topo_ex) { Catalog::TopologyError.new("kaboom") }
-
-  before do
-    allow(topological_inventory).to receive(:call).and_yield(api_instance)
-    allow(api_instance).to receive(:show_service_offering_icon).and_return(topology_service_offering_icon)
-  end
+  let!(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
+  let!(:icon) { create(:icon, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
 
   describe "#show" do
+    before { get "#{api}/icons/#{icon.id}", :headers => default_headers }
+
+    it "returns a 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns the icon specified" do
+      expect(json["id"]).to eq icon.id.to_s
+    end
+  end
+
+  describe "#destroy" do
+    before { delete "#{api}/icons/#{icon.id}", :headers => default_headers }
+
+    it "returns a 204" do
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "deletes the icon" do
+      expect { Icon.find(icon.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe "#create" do
+    before { post "#{api}/icons", :params => params, :headers => default_headers }
+
+    context "when providing proper parameters" do
+      let(:params) { { :data => "<svg rel=\"stylesheet\">thing</svg>", :source_id => "27", :source_ref => "icon_ref" } }
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns the created icon" do
+        expect(json["data"]).to eq params[:data]
+        expect(json["source_id"]).to eq params[:source_id]
+      end
+    end
+
+    context "when passing in improper parameters" do
+      let(:params) { { :not_the_right_param => "whereami" } }
+
+      it "throws a 422" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:params) { { :data => "<svg rel=\"new_data\">thing</svg" } }
+    before { patch "#{api}/icons/#{icon.id}", :params => params, :headers => default_headers }
+
+    it "returns a 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the fields passed in" do
+      expect(json["data"]).to eq params[:data]
+    end
+  end
+
+  describe "#show_icon" do
     context "when the icon exists" do
       it "/portfolio_items/{portfolio_item_id}/icon returns the icon" do
-        expect(api_instance).to receive(:show_service_offering_icon).with(topology_service_offering_icon.id).and_return(topology_service_offering_icon)
-
         get "#{api}/portfolio_items/#{portfolio_item.id}/icon", :headers => default_headers
 
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq "image/svg+xml"
+      end
+
+      it "/icons/{icon_id}/icon_data returns the icon" do
+        get "#{api}/icons/#{icon.id}/icon_data", :headers => default_headers
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq "image/svg+xml"
       end
     end
 
     context "when the icon does not exist" do
-      before do
-        portfolio_item.update(:service_offering_icon_ref => nil)
-      end
+      before { icon.update!(:portfolio_item_id => nil) }
 
       it "returns not found" do
         get "#{api}/portfolio_items/#{portfolio_item.id}/icon", :headers => default_headers
 
         expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context "when there is an error fetching the icon" do
-      before do
-        allow(api_instance).to receive(:show_service_offering_icon).and_raise(topo_ex)
-      end
-
-      it "returns a 503" do
-        get "#{api}/portfolio_items/#{portfolio_item.id}/icon", :headers => default_headers
-
-        expect(response).to have_http_status(:service_unavailable)
       end
     end
   end

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -65,7 +65,7 @@ describe "IconsRequests", :type => :request do
     end
   end
 
-  describe "#show_icon" do
+  describe "#raw_icon" do
     context "when the icon exists" do
       it "/portfolio_items/{portfolio_item_id}/icon returns the icon" do
         get "#{api}/portfolio_items/#{portfolio_item.id}/icon", :headers => default_headers

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -358,4 +358,23 @@ describe "PortfolioItemRequests", :type => :request do
       end
     end
   end
+
+  describe '#add_icon_to_portfolio_item' do
+    let!(:icon) { create(:icon, :tenant_id => tenant.id) }
+
+    context "when adding an icon to a portfolio_item" do
+      before do
+        post "#{api}/portfolio_items/#{portfolio_item.id}/icon", :params => { :icon_id => icon.id }, :headers => default_headers
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "adds the icon to the portfolio_item" do
+        portfolio_item.reload
+        expect(portfolio_item.icon.id).to eq icon.id
+      end
+    end
+  end
 end

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -10,6 +10,7 @@ describe ServiceOffering::AddToPortfolioItem do
   let(:params) { HashWithIndifferentAccess.new(:name => user_defined_name, :description => user_defined_description, :service_offering_ref => service_offering_ref) }
 
   let(:topology_service_offering) { fully_populated_service_offering }
+  let(:service_offering_icon) { fully_populated_service_offering_icon }
   let(:topological_inventory) do
     class_double("TopologicalInventory")
       .as_stubbed_const(:transfer_nested_constants => true)
@@ -18,6 +19,7 @@ describe ServiceOffering::AddToPortfolioItem do
   before do
     allow(topological_inventory).to receive(:call).and_yield(api_instance)
     allow(api_instance).to receive(:show_service_offering).with(service_offering_ref).and_return(topology_service_offering)
+    allow(api_instance).to receive(:show_service_offering_icon).with(topology_service_offering.service_offering_icon_id).and_return(service_offering_icon)
   end
 
   context "user provided params" do
@@ -37,6 +39,10 @@ describe ServiceOffering::AddToPortfolioItem do
         result = subject.process
         expect(result.item.name).to eq("test name")
         expect(result.item.description).to eq("test description")
+
+        expect(result.item.icon.data).to eq service_offering_icon.data
+        expect(result.item.icon.source_id).to eq service_offering_icon.source_id
+        expect(result.item.icon.source_ref).to eq service_offering_icon.source_ref
       end
     end
   end

--- a/spec/support/service_offering_topological_service_offering_helper.rb
+++ b/spec/support/service_offering_topological_service_offering_helper.rb
@@ -18,4 +18,12 @@ module ServiceOfferingHelper
   def build_service_offering(params)
     TopologicalInventoryApiClient::ServiceOffering.new(params)
   end
+
+  def fully_populated_service_offering_icon
+    TopologicalInventoryApiClient::ServiceOfferingIcon.new(
+      :data       => "<svg data=example>thing</svg>",
+      :source_id  => "127",
+      :source_ref => "icon-ref"
+    )
+  end
 end


### PR DESCRIPTION
Adds `/icons` and various operations for us to support custom icons. 

Currently everything has to be done manually, like so:
```
POST /icons                   # create an icon
PATCH /portfolio_items/{id}   # update the icon on the portfolio_item
DELETE /icons/{id}            # delete the old icon.
```
~~Question: looking for opinions on adding a service class (and subsequently map it to `/icons/{id}/override` or something that updates the specified portfolio_item's icon_ref with the new icon and cleans up the old one or something.~~
Override functionality moved here: https://github.com/ManageIQ/catalog-api/pull/324
relates to https://projects.engineering.redhat.com/browse/SSP-33
fixes: https://projects.engineering.redhat.com/browse/SSP-461