### PR TITLE
Increase the limit of data sent back when making get_principal_access call

### DIFF
--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -1,6 +1,7 @@
 module RBAC
   class Access
     attr_reader :acl
+    DEFAULT_LIMIT = 500
     def initialize(resource, verb)
       @resource = resource
       @verb     = verb
@@ -11,7 +12,7 @@ module RBAC
     def process
       RBAC::Service.call(RBACApiClient::AccessApi) do |api|
         Rails.logger.info("Fetch access list for #{@app_name}")
-        @acl = RBAC::Service.paginate(api, :get_principal_access, {}, @app_name).select do |item|
+        @acl = RBAC::Service.paginate(api, :get_principal_access, {:limit => DEFAULT_LIMIT}, @app_name).select do |item|
           Rails.logger.info("Found ACL: #{item}")
           @regexp.match(item.permission)
         end

--- a/spec/lib/rbac/access_spec.rb
+++ b/spec/lib/rbac/access_spec.rb
@@ -5,6 +5,7 @@ describe RBAC::Access do
   let(:rbac_access) { described_class.new(resource, verb) }
   let(:api_instance) { double }
   let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:opts) { { :limit => RBAC::Access::DEFAULT_LIMIT }}
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi).and_yield(api_instance)
@@ -12,7 +13,7 @@ describe RBAC::Access do
 
   it "fetches the array of plans" do
     with_modified_env :APP_NAME => app_name do
-      allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return([access1])
+      allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return([access1])
       svc_obj = rbac_access.process
       expect(svc_obj.acl.count).to eq(1)
       expect(svc_obj.accessible?).to be_truthy
@@ -22,7 +23,7 @@ describe RBAC::Access do
 
   it "* in id gives access to all instances" do
     with_modified_env :APP_NAME => app_name do
-      allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return([admin_access])
+      allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return([admin_access])
       svc_obj = rbac_access.process
       expect(svc_obj.acl.count).to eq(1)
       expect(svc_obj.accessible?).to be_truthy

--- a/spec/lib/rbac/owner_access_spec.rb
+++ b/spec/lib/rbac/owner_access_spec.rb
@@ -4,6 +4,7 @@ describe RBAC::Access do
   let(:rbac_access) { described_class.new(owner_resource, verb) }
   let(:api_instance) { double }
   let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:opts) { { :limit => RBAC::Access::DEFAULT_LIMIT }}
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi).and_yield(api_instance)
@@ -12,7 +13,7 @@ describe RBAC::Access do
   shared_examples_for "#owner_scoped?" do
     it "validate scope" do
       with_modified_env :APP_NAME => app_name do
-        allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return(acls)
+        allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return(acls)
         svc_obj = rbac_access.process
         expect(svc_obj.acl.count).to eq(acl_count)
         expect(svc_obj.accessible?).to be_truthy


### PR DESCRIPTION
The get_principal_access call causes a Policy Resolution on the RBAC service
which is repeated for every paginated call, causing a slow down
in fetching ACL's and a Gateway timeout (504) error when accessing portfolios or
creating portfolios. Bumped the limit to 500 till the RBAC service
can start caching the results. The default offset is 10 which for 150 objects will cause 15 calls to be made to the RBAC service and 15 policy resolutions