### PR TITLE
Add override Icon functionality

### DIFF
--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -31,6 +31,12 @@ module Api
                   :disposition => 'inline')
       end
 
+      def override_icon
+        overriden_icon = Catalog::OverrideIcon.new(params.require(:icon_id), params.require(:portfolio_item_id))
+
+        render :json => overriden_icon.process.icon
+      end
+
       private
 
       def icon_params

--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def destroy
-        Icon.find(params.require(:id)).destroy
+        Catalog::SoftDelete.new(Icon.find(params.require(:id))).process
         head :no_content
       end
 
@@ -33,7 +33,6 @@ module Api
 
       def override_icon
         overriden_icon = Catalog::OverrideIcon.new(params.require(:icon_id), params.require(:portfolio_item_id))
-
         render :json => overriden_icon.process.icon
       end
 

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -68,11 +68,11 @@ module Api
 
       def portfolio_item_params
         params.require(:service_offering_ref)
-        params.permit(:service_offering_ref, :workflow_ref)
+        params.permit(:service_offering_ref, :workflow_ref, :icon_id)
       end
 
       def portfolio_item_patch_params
-        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref)
+        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref, :icon_id)
       end
 
       def portfolio_copy_params

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -68,11 +68,11 @@ module Api
 
       def portfolio_item_params
         params.require(:service_offering_ref)
-        params.permit(:service_offering_ref, :workflow_ref, :icon_id)
+        params.permit(:service_offering_ref, :workflow_ref)
       end
 
       def portfolio_item_patch_params
-        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref, :icon_id)
+        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref)
       end
 
       def portfolio_copy_params

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -61,7 +61,7 @@ module Api
       def add_icon_to_portfolio_item
         icon = Icon.find(params.require(:icon_id))
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
-        render :json => portfolio_item.add_icon(icon)
+        render :json => portfolio_item.icons << icon
       end
 
       private

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -1,5 +1,7 @@
 class Icon < ApplicationRecord
   acts_as_tenant(:tenant)
+  include Discard::Model
+  default_scope -> { kept }
 
   belongs_to :portfolio_item
   validates :data, :presence => true

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -5,13 +5,9 @@ class PortfolioItem < ApplicationRecord
 
   default_scope -> { kept }
 
-  has_one :icon, :dependent => :destroy
+  has_many :icons, :dependent => :destroy
   belongs_to :portfolio
   validates :service_offering_ref, :presence => true
-
-  def add_icon(icon)
-    self.icon = icon
-  end
 
   def resolved_workflow_refs
     # TODO: Add lookup to platform workflow ref

--- a/app/services/catalog/override_icon.rb
+++ b/app/services/catalog/override_icon.rb
@@ -1,0 +1,17 @@
+module Catalog
+  class OverrideIcon
+    attr_reader :icon
+
+    def initialize(icon_id, portfolio_item_id)
+      @icon = Icon.find(icon_id)
+      @portfolio_item = PortfolioItem.find(portfolio_item_id)
+    end
+
+    def process
+      @portfolio_item.icon.destroy
+      @portfolio_item.icon = @icon
+
+      self
+    end
+  end
+end

--- a/app/services/catalog/override_icon.rb
+++ b/app/services/catalog/override_icon.rb
@@ -8,8 +8,9 @@ module Catalog
     end
 
     def process
-      @portfolio_item.icon.destroy
-      @portfolio_item.icon = @icon
+      # there should only ever be one icon, the others are discarded.
+      Catalog::SoftDelete.new(@portfolio_item.icons.first).process
+      @portfolio_item.icons << @icon
 
       self
     end

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -16,7 +16,7 @@ module ServiceOffering
 
       # Get the fields that we're going to pull over
       @item = PortfolioItem.create!(generate_attributes)
-      @item.icon = create_icon(@service_offering.service_offering_icon_id)
+      @item.icons << create_icon(@service_offering.service_offering_icon_id)
       self
     rescue StandardError => e
       Rails.logger.error("Service Offering Ref: #{@params[:service_offering_ref]} #{e.message}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
         post :undelete, :action => 'undestroy', :controller => 'portfolio_items'
       end
       resources :icons, :only => [:create, :destroy, :show, :update] do
+        post :override, :to => 'icons#override_icon'
         get :icon_data, :to => 'icons#raw_icon'
       end
     end

--- a/db/migrate/20190718144713_add_discarded_at_to_icons.rb
+++ b/db/migrate/20190718144713_add_discarded_at_to_icons.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToIcons < ActiveRecord::Migration[5.2]
+  def change
+    add_column :icons, :discarded_at, :datetime
+    add_index :icons, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_25_173111) do
+ActiveRecord::Schema.define(version: 2019_07_18_144713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,8 @@ ActiveRecord::Schema.define(version: 2019_06_25_173111) do
     t.bigint "tenant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_icons_on_discarded_at"
     t.index ["tenant_id"], name: "index_icons_on_tenant_id"
   end
 

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1639,6 +1639,51 @@
         }
       }
     },
+    "/icons/{id}/override": {
+      "post": {
+        "tags": [
+          "Icon"
+        ],
+        "summary": "Override the specified Portfolio Item's Icon",
+        "operationId": "overrideIcon",
+        "description": "Override the specified Portfolio Item's Icon",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new Icon",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Icon"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Icon Not Found/Not Present on Portfolio Item"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OverrideIcon"
+              }
+            }
+          }
+        }
+      }
+    },
     "/portfolio_items/{portfolio_item_id}/next_name": {
       "get": {
         "tags": [
@@ -1954,6 +1999,17 @@
             "title": "Icon Id",
             "example": "100",
             "description": "This is the ID of the icon object."
+          }
+        }
+      },
+      "OverrideIcon": {
+        "type": "object",
+        "properties": {
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "example": "100",
+            "description": "Tthe ID of the portfolio which the icon will override"
           }
         }
       },

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1670,7 +1670,7 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "404": {
-            "description": "Icon Not Found/Not Present on Portfolio Item"
+            "description": "Icon Not Found."
           }
         },
         "requestBody": {

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -91,4 +91,17 @@ describe "IconsRequests", :type => :request do
       end
     end
   end
+
+  describe "#override_icon" do
+    let!(:new_icon) { create(:icon, :tenant_id => tenant.id) }
+
+    it "overrides the icon" do
+      post "#{api}/icons/#{new_icon.id}/override", :params => { :portfolio_item_id => portfolio_item.id }, :headers => default_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json["id"]).to eq new_icon.id.to_s
+
+      expect { Icon.find(icon.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
 end

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -94,14 +94,19 @@ describe "IconsRequests", :type => :request do
 
   describe "#override_icon" do
     let!(:new_icon) { create(:icon, :tenant_id => tenant.id) }
+    before { post "#{api}/icons/#{new_icon.id}/override", :params => { :portfolio_item_id => portfolio_item.id }, :headers => default_headers }
+
+    it "returns the new icon" do
+      expect(json["id"]).to eq new_icon.id.to_s
+    end
 
     it "overrides the icon" do
-      post "#{api}/icons/#{new_icon.id}/override", :params => { :portfolio_item_id => portfolio_item.id }, :headers => default_headers
+      expect(portfolio_item.icons.first.id).to eq new_icon.id
+    end
 
-      expect(response).to have_http_status(:ok)
-      expect(json["id"]).to eq new_icon.id.to_s
-
+    it "soft-deletes the old one" do
       expect { Icon.find(icon.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect(Icon.with_discarded.find(icon.id)).to be_truthy
     end
   end
 end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -373,7 +373,7 @@ describe "PortfolioItemRequests", :type => :request do
 
       it "adds the icon to the portfolio_item" do
         portfolio_item.reload
-        expect(portfolio_item.icon.id).to eq icon.id
+        expect(portfolio_item.icons.first.id).to eq icon.id
       end
     end
   end

--- a/spec/services/catalog/override_icon_spec.rb
+++ b/spec/services/catalog/override_icon_spec.rb
@@ -13,7 +13,7 @@ describe Catalog::OverrideIcon do
       end
 
       it "sets the portfolio_item icon to the one specified" do
-        expect(portfolio_item.icon.id).to eq icon2.id
+        expect(portfolio_item.icons.first.id).to eq icon2.id
       end
     end
   end

--- a/spec/services/catalog/override_icon_spec.rb
+++ b/spec/services/catalog/override_icon_spec.rb
@@ -1,0 +1,20 @@
+describe Catalog::OverrideIcon do
+  let(:tenant) { create(:tenant) }
+  let!(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
+  let!(:icon1) { create(:icon, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id) }
+  let!(:icon2) { create(:icon, :tenant_id => tenant.id) }
+
+  describe "#process" do
+    context "when overriding an icon" do
+      before { described_class.new(icon2.id, portfolio_item.id).process }
+
+      it "destroys the old icon" do
+        expect { Icon.find(icon1.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      it "sets the portfolio_item icon to the one specified" do
+        expect(portfolio_item.icon.id).to eq icon2.id
+      end
+    end
+  end
+end

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -40,9 +40,9 @@ describe ServiceOffering::AddToPortfolioItem do
         expect(result.item.name).to eq("test name")
         expect(result.item.description).to eq("test description")
 
-        expect(result.item.icon.data).to eq service_offering_icon.data
-        expect(result.item.icon.source_id).to eq service_offering_icon.source_id
-        expect(result.item.icon.source_ref).to eq service_offering_icon.source_ref
+        expect(result.item.icons.first.data).to eq service_offering_icon.data
+        expect(result.item.icons.first.source_id).to eq service_offering_icon.source_id
+        expect(result.item.icons.first.source_ref).to eq service_offering_icon.source_ref
       end
     end
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-33

This PR contains the Icon Override functionality, built off of #318 so it contains both changes right now. 

It adds this endpoint:
`/icons/{id}/override :portfolio_item_id => 7` 
which overrides the portfolio_item icon specified with the path icon.