### PR TITLE
Fix copy_name logic to not prefix with "Copy of" when using the next_name endpoint prior to creating the copy

### DIFF
--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -31,7 +31,12 @@ module Catalog
     end
 
     def new_name(name, field)
-      Catalog::NameAdjust.create_copy_name(name, @to_portfolio.portfolio_items.pluck(field))
+      portfolio_names = @to_portfolio.portfolio_items.pluck(field)
+      if portfolio_names.include?(name)
+        Catalog::NameAdjust.create_copy_name(name, portfolio_names)
+      else
+        name
+      end
     end
   end
 end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -307,7 +307,7 @@ describe "PortfolioItemRequests", :type => :request do
 
       it "returns the name specified" do
         copy_portfolio_item
-        expect(json["display_name"]).to eq "Copy of " + params[:portfolio_item_name]
+        expect(json["display_name"]).to eq params[:portfolio_item_name]
       end
     end
 
@@ -327,10 +327,7 @@ describe "PortfolioItemRequests", :type => :request do
         expect(json["description"]).to eq portfolio_item.description
         expect(json["owner"]).to eq portfolio_item.owner
         expect(json["workflow_ref"]).to eq portfolio_item.workflow_ref
-      end
-
-      it "prefixes the name with Copy of" do
-        expect(json["name"]).to match(/^Copy of.*/)
+        expect(json["name"]).to eq portfolio_item.name
       end
     end
 

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -354,7 +354,7 @@ describe 'Portfolios API' do
       it "copies the portfolio item over" do
         item = PortfolioItem.find(Portfolio.find(json["id"]).portfolio_items.first.id)
 
-        expect(item.name).to eq "Copy of " + portfolio_item.name
+        expect(item.name).to eq portfolio_item.name
         expect(item.description).to eq portfolio_item.description
         expect(item.owner).to eq portfolio_item.owner
       end

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -24,13 +24,15 @@ describe Catalog::CopyPortfolioItem do
 
     context "when copying into a different portfolio" do
       let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio2.id } }
+      let(:new) { copy_portfolio_item.new_portfolio_item }
 
       it "makes a complete copy of the portfolio_item" do
-        new = copy_portfolio_item.new_portfolio_item
-
         expect(new.description).to eq portfolio_item.description
         expect(new.owner).to eq portfolio_item.owner
-        expect(new.name).to match(/^Copy of.*/)
+      end
+
+      it "does not modify the name with 'Copy of'" do
+        expect(new.name).to eq portfolio_item.name
       end
     end
 

--- a/spec/services/catalog/copy_portfolio_spec.rb
+++ b/spec/services/catalog/copy_portfolio_spec.rb
@@ -26,7 +26,7 @@ describe Catalog::CopyPortfolio do
       it "copies over the portfolio_items fields" do
         items = new_portfolio.portfolio_items
 
-        expect(items.collect(&:name)).to match_array(["Copy of #{portfolio_item1.name}", "Copy of #{portfolio_item2.name}"])
+        expect(items.collect(&:name)).to match_array([portfolio_item1.name, portfolio_item2.name])
         expect(items.collect(&:description)).to match_array([portfolio_item1.description, portfolio_item2.description])
         expect(items.collect(&:owner)).to match_array([portfolio_item1.owner, portfolio_item2.owner])
       end


### PR DESCRIPTION
Found a bug in the UI after the frontend started using the `next_name` endpoint.

Before it was running name resolution every time, but that doesn't work if the `next_name` output is passed in since we already ran name resolution once, so we now **only** run name resolution if there is a conflict in the new portfolio.