### PR TITLE
Add settings per Tenant

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -53,6 +53,11 @@ module Api
         def invalid_parameter(str)
           raise Catalog::InvalidParameter, str
         end
+
+        def org_admin_check
+          return unless RBAC::Access.enabled?
+          raise Catalog::NotAuthorized unless ManageIQ::API::Common::Request.current.user.org_admin?
+        end
       end
     end
   end

--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -54,9 +54,11 @@ module Api
           raise Catalog::InvalidParameter, str
         end
 
-        def org_admin_check
+        def catalog_admin_check
           return unless RBAC::Access.enabled?
-          raise Catalog::NotAuthorized unless ManageIQ::API::Common::Request.current.user.org_admin?
+
+          access_obj = RBAC::Access.new("portfolios", "write").process
+          raise Catalog::NotAuthorized unless access_obj.catalog_admin?
         end
       end
     end

--- a/app/controllers/api/v1x0/settings_controller.rb
+++ b/app/controllers/api/v1x0/settings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1x0
     class SettingsController < ApplicationController
-      before_action :org_admin_check
+      before_action :catalog_admin_check
 
       def index
         settings = Catalog::TenantSettings.new(tenant)

--- a/app/controllers/api/v1x0/settings_controller.rb
+++ b/app/controllers/api/v1x0/settings_controller.rb
@@ -4,7 +4,8 @@ module Api
       before_action :org_admin_check
 
       def index
-        render :json => tenant.settings
+        settings = Catalog::TenantSettings.new(tenant)
+        render :json => settings.process.response
       end
 
       def show

--- a/app/controllers/api/v1x0/settings_controller.rb
+++ b/app/controllers/api/v1x0/settings_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  module V1x0
+    class SettingsController < ApplicationController
+      before_action :org_admin_check
+
+      def index
+        render :json => tenant.settings
+      end
+
+      def show
+        render :json => { params.require(:id) => setting(params.require(:id)) }
+      end
+
+      def create
+        tenant.add_setting(params.require(:name), params.require(:value))
+        render :json => { params[:name] => setting(params[:name]) }
+      end
+
+      def update
+        tenant.update_setting(params.require(:id), params.require(:value))
+        render :json => { params[:id] => setting(params[:id]) }
+      end
+
+      def destroy
+        tenant.delete_setting(params.require(:id))
+        head :no_content
+      end
+
+      private
+
+      def setting(name)
+        tenant.settings[name]
+      end
+
+      def tenant
+        ActsAsTenant.current_tenant
+      end
+    end
+  end
+end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -3,13 +3,13 @@ class Tenant < ApplicationRecord
 
   after_initialize :setup_settings, :unless => proc { settings.nil? }
 
-  def add_settings(setting)
-    settings.merge!(setting)
+  def add_setting(name, value)
+    settings[name] = value
     save!
   end
 
-  def update_setting(setting)
-    add_settings(setting)
+  def update_setting(name, value)
+    add_setting(name, value)
   end
 
   def delete_setting(setting)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,7 +1,23 @@
 class Tenant < ApplicationRecord
   validates :external_tenant, :uniqueness => true, :presence => true
 
-  after_initialize :setup_settings, :unless => Proc.new { settings.nil? }
+  after_initialize :setup_settings, :unless => proc { settings.nil? }
+
+  def add_settings(setting)
+    settings.merge!(setting)
+    save!
+  end
+
+  def update_setting(setting)
+    add_settings(setting)
+  end
+
+  def delete_setting(setting)
+    settings.delete(setting.to_s)
+    save!
+  end
+
+  private
 
   def setup_settings
     settings.keys.each do |key|

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,3 +1,13 @@
 class Tenant < ApplicationRecord
   validates :external_tenant, :uniqueness => true, :presence => true
+
+  after_initialize :setup_settings, :unless => Proc.new { settings.nil? }
+
+  def setup_settings
+    settings.keys.each do |key|
+      define_singleton_method(key) do
+        settings[key]
+      end
+    end
+  end
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -4,15 +4,22 @@ class Tenant < ApplicationRecord
   after_initialize :setup_settings, :unless => proc { settings.nil? }
 
   def add_setting(name, value)
+    raise Catalog::InvalidParameter if settings[name.to_s].present?
+
     settings[name] = value
     save!
   end
 
   def update_setting(name, value)
-    add_setting(name, value)
+    raise ActiveRecord::RecordNotFound if settings[name.to_s].nil?
+
+    settings[name] = value
+    save!
   end
 
   def delete_setting(setting)
+    raise ActiveRecord::RecordNotFound if settings[setting.to_s].nil?
+
     settings.delete(setting.to_s)
     save!
   end

--- a/app/services/catalog/tenant_settings.rb
+++ b/app/services/catalog/tenant_settings.rb
@@ -1,0 +1,24 @@
+module Catalog
+  class TenantSettings
+    attr_reader :response
+
+    def initialize(tenant)
+      @tenant = tenant
+    end
+
+    def process
+      @response = {
+        :current => @tenant.settings,
+        :schema  => JSON.parse(schema)
+      }
+
+      self
+    end
+
+    private
+
+    def schema
+      @schema ||= File.read(Rails.root.join("schemas", "json", "tenant_settings.json"))
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
         post :override, :to => 'icons#override_icon'
         get :icon_data, :to => 'icons#raw_icon'
       end
+      resources :settings
     end
   end
 end

--- a/db/migrate/20190702182800_add_settings_to_tenant.rb
+++ b/db/migrate/20190702182800_add_settings_to_tenant.rb
@@ -1,5 +1,5 @@
 class AddSettingsToTenant < ActiveRecord::Migration[5.2]
   def change
-    add_column :tenants, :settings, :jsonb
+    add_column :tenants, :settings, :jsonb, :default => {}
   end
 end

--- a/db/migrate/20190702182800_add_settings_to_tenant.rb
+++ b/db/migrate/20190702182800_add_settings_to_tenant.rb
@@ -1,0 +1,5 @@
+class AddSettingsToTenant < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tenants, :settings, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 2019_07_18_144713) do
     t.bigint "external_tenant"
     t.string "name"
     t.string "description"
-    t.jsonb "settings"
+    t.jsonb "settings", default: {}
     t.index ["external_tenant"], name: "index_tenants_on_external_tenant"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2019_07_18_144713) do
     t.bigint "external_tenant"
     t.string "name"
     t.string "description"
+    t.jsonb "settings"
     t.index ["external_tenant"], name: "index_tenants_on_external_tenant"
   end
 

--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -36,6 +36,11 @@ module RBAC
       @ids.include?('*') ? false : owner_scope_filter?
     end
 
+    def catalog_admin?
+      generate_ids
+      @ids.include?('*')
+    end
+
     def self.enabled?
       ENV['BYPASS_RBAC'].blank?
     end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1722,6 +1722,163 @@
           }
         }
       }
+    },
+    "/settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "List Tenant Settings",
+        "description": "List Tenant Settings",
+        "operationId": "listSettings",
+        "responses": {
+          "200": {
+            "description": "A json object with key/value pairs of tenant settings",
+            "content": {
+              "application/json": {
+                "example": "{\n  \"default_workflow\": \"2\",\n  \"icon\": \"<svg rel='stylesheet'>thing</svg>\"\n}\n"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Create Tenant Setting",
+        "description": "Create Tenant Setting",
+        "operationId": "createSetting",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Setting"
+              }
+            }
+          },
+          "description": "Json encoded key/value pair to create a new setting",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Succesfully added the new setting.",
+            "content": {
+              "application/json": {
+                "example": "{ \n  \"default_workflow\": \"2\" \n} \n"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidEntity"
+          }
+        }
+      }
+    },
+    "/settings/{setting_name}": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get a specific Tenant Setting",
+        "description": "Get a specific Tenant Setting",
+        "operationId": "showSetting",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SettingName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested Tenant Setting",
+            "content": {
+              "application/json": {
+                "example": "{ \n  \"default_workflow\": \"2\" \n} \n"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidEntity"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Update a Tenant Setting",
+        "description": "Update a Tenant Setting",
+        "operationId": "updateSetting",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SettingName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated Tenant Setting",
+            "content": {
+              "application/json": {
+                "example": "{ \n  \"default_workflow\": \"2\" \n} \n"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidEntity"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Delete a Tenant Setting",
+        "description": "Delete a Tenant Setting",
+        "operationId": "destroySetting",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SettingName"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tenant Setting successfully deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidEntity"
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -1799,6 +1956,15 @@
         "name": "destination_portfolio_id",
         "description": "The destination portfolio to compare names against",
         "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "SettingName": {
+        "name": "setting_name",
+        "in": "path",
+        "description": "name of the setting",
+        "required": true,
         "schema": {
           "type": "string"
         }
@@ -1999,6 +2165,21 @@
             "title": "Icon Id",
             "example": "100",
             "description": "This is the ID of the icon object."
+          }
+        }
+      },
+      "Setting": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Setting Name",
+            "example": "default_workflow"
+          },
+          "value": {
+            "type": "string",
+            "title": "Setting Value",
+            "example": 2
           }
         }
       },
@@ -2552,7 +2733,11 @@
             "items": {
               "type": "string"
             },
-	    "example": ["catalog:portfolios:read", "catalog:portfolios:write", "catalog:portfolios:order"]
+            "example": [
+              "catalog:portfolios:read",
+              "catalog:portfolios:write",
+              "catalog:portfolios:order"
+            ]
           },
           "group_uuids": {
             "type": "array",

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1733,10 +1733,13 @@
         "operationId": "listSettings",
         "responses": {
           "200": {
-            "description": "A json object with key/value pairs of tenant settings",
+            "description": "The current tenant settings and schema",
             "content": {
               "application/json": {
-                "example": "{\n  \"default_workflow\": \"2\",\n  \"icon\": \"<svg rel='stylesheet'>thing</svg>\"\n}\n"
+                "schema": {
+                  "$ref": "#/components/schemas/TenantSettings"
+                },
+                "example": "{\n  \"current\": {\n    \"default_workflow\": \"2\",\n    \"icon\": \"<svg rel='stylesheet'>thing</svg>\"\n  },\n  \"schema\": {}\n}\n"
               }
             }
           },
@@ -1787,7 +1790,7 @@
         }
       }
     },
-    "/settings/{setting_name}": {
+    "/settings/{name}": {
       "get": {
         "tags": [
           "Settings"
@@ -1961,7 +1964,7 @@
         }
       },
       "SettingName": {
-        "name": "setting_name",
+        "name": "name",
         "in": "path",
         "description": "name of the setting",
         "required": true,
@@ -2718,6 +2721,26 @@
         "type": "object",
         "title": "Provider Control Parameters",
         "description": "JSON Schema for Provider control parameters."
+      },
+      "TenantSettings": {
+        "type": "object",
+        "title": "Tenant Settings",
+        "description": "The tenant settings and schema",
+        "properties": {
+          "current": {
+            "type": "object",
+            "title": "Current Settings",
+            "description": "The current settings for this tenant"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/TenantSettingsSchema"
+          }
+        }
+      },
+      "TenantSettingsSchema": {
+        "type": "object",
+        "title": "Tenant Settings Schema",
+        "description": "JSON Schema for the Tenant Settings"
       },
       "SharePolicy": {
         "type": "object",

--- a/schemas/json/tenant_settings.json
+++ b/schemas/json/tenant_settings.json
@@ -1,0 +1,22 @@
+{
+  "title": "Tenant Settings",
+  "description": "Catalog Tenant Settings",
+  "type": "object",
+  "required": [
+    "default_workflow"
+  ],
+  "properties": {
+    "default_workflow": {
+      "type": "string",
+      "title": "Default Workflow",
+      "enum": [
+          "Auto-Approve"
+        ]
+    },
+    "icon": {
+      "type": "string",
+      "title": "Icon",
+      "default": ""
+    }
+  }
+}

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,0 +1,53 @@
+describe Tenant, :type => :model do
+  let(:tenant) do
+    create(:tenant,
+           :settings => {
+             :icon             => "<svg rel='stylesheet'>image</svg>",
+             :default_workflow => "1"
+           })
+  end
+  let(:retreived_tenant) { Tenant.find(tenant.id) }
+
+  describe "#setup_settings" do
+    context "when retreiving from the db" do
+      it "populates the keys as methods" do
+        expect(retreived_tenant.icon).to eq tenant.settings["icon"]
+        expect(retreived_tenant.default_workflow).to eq tenant.settings["default_workflow"]
+      end
+    end
+
+    context "when manually adding a new setting and retreiving the key" do
+      before do
+        tenant.update!(:settings => tenant.settings.merge!(:a_setting => "nerp"))
+      end
+
+      it "has the new setting on the hash" do
+        expect(retreived_tenant.a_setting).to eq "nerp"
+      end
+    end
+  end
+
+  describe "#add_settings" do
+    before { tenant.add_settings(:telephone => "555-867-5309") }
+
+    it "adds the specified setting" do
+      expect(retreived_tenant.telephone).to eq "555-867-5309"
+    end
+  end
+
+  describe "#update_setting" do
+    before { tenant.update_setting(:default_workflow => "2") }
+
+    it "updates the setting" do
+      expect(retreived_tenant.default_workflow).to eq "2"
+    end
+  end
+
+  describe "#delete_setting" do
+    before { tenant.delete_setting(:icon) }
+
+    it "deletes the setting" do
+      expect { retreived_tenant.icon }.to raise_exception(NoMethodError)
+    end
+  end
+end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -28,7 +28,7 @@ describe Tenant, :type => :model do
   end
 
   describe "#add_settings" do
-    before { tenant.add_settings(:telephone => "555-867-5309") }
+    before { tenant.add_setting(:telephone, "555-867-5309") }
 
     it "adds the specified setting" do
       expect(retreived_tenant.telephone).to eq "555-867-5309"
@@ -36,7 +36,7 @@ describe Tenant, :type => :model do
   end
 
   describe "#update_setting" do
-    before { tenant.update_setting(:default_workflow => "2") }
+    before { tenant.update_setting(:default_workflow, "2") }
 
     it "updates the setting" do
       expect(retreived_tenant.default_workflow).to eq "2"

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -1,0 +1,80 @@
+describe 'Settings API' do
+  let!(:tenant) do
+    create(:tenant,
+           :settings => {
+             :icon             => "<svg rel='stylesheet'>image</svg>",
+             :default_workflow => "1"
+           })
+  end
+  let(:retreived_tenant) { Tenant.find(tenant.id) }
+
+  let(:org_admin_hash) do
+    user = default_user_hash
+    user["identity"]["user"]["is_org_admin"] = true
+    encoded_user_hash(user)
+  end
+
+  let(:manipulated_headers) do
+    { 'x-rh-identity'            => org_admin_hash,
+      'x-rh-insights-request-id' => 'gobbledygook' }
+  end
+
+  context "when the user is an org admin" do
+    describe "#index" do
+      before { get "#{api}/settings", :headers => manipulated_headers }
+
+      it "returns the index of settings per tenant" do
+        expect(response).to have_http_status(:ok)
+        expect(json["icon"]).to eq retreived_tenant.icon
+        expect(json["default_workflow"]).to eq retreived_tenant.default_workflow
+      end
+    end
+
+    describe "#show" do
+      before { get "#{api}/settings/icon", :headers => manipulated_headers }
+
+      it "returns the specified setting" do
+        expect(response).to have_http_status(:ok)
+        expect(json["icon"]).to eq retreived_tenant.icon
+      end
+    end
+
+    describe "#create" do
+      let(:params) { { :name => "new_setting", :value => "17" } }
+      before { post "#{api}/settings", :headers => manipulated_headers, :params => params }
+
+      it "creates a new setting" do
+        expect(response).to have_http_status(:ok)
+        expect(json["new_setting"]).to eq params[:value]
+      end
+    end
+
+    describe "#update" do
+      let(:params) { { :value => "<svg rel='stylesheet'>new image!</svg>" } }
+
+      before { patch "#{api}/settings/icon", :headers => manipulated_headers, :params => params }
+
+      it "patches the settings" do
+        expect(response).to have_http_status(:ok)
+        expect(json["icon"]).to eq params[:value]
+      end
+    end
+
+    describe "#delete" do
+      before { delete "#{api}/settings/default_workflow", :headers => manipulated_headers }
+
+      it "deletes the specified setting" do
+        expect(response).to have_http_status(:no_content)
+        expect(retreived_tenant.settings.key?("default_workflow")).to be_falsey
+      end
+    end
+  end
+
+  context "when the user is not an org admin" do
+    it "does not allow any operations" do
+      get "#{api}/settings", :headers => default_headers
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/services/catalog/tenant_settings_spec.rb
+++ b/spec/services/catalog/tenant_settings_spec.rb
@@ -1,0 +1,13 @@
+describe Catalog::TenantSettings do
+  let(:tenant) { create(:tenant, :settings => { :default_workflow => "1" }) }
+  let(:settings) { described_class.new(tenant).process }
+
+  it 'returns the current settings' do
+    expect(settings.response[:current]["default_workflow"]).to eq "1"
+  end
+
+  it 'returns the json schema' do
+    json = JSON.parse(File.read(Rails.root.join("schemas", "json", "tenant_settings.json")))
+    expect(settings.response[:schema]).to eq json
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-533

This PR adds a field on `Tenant` which is a jsonb column that holds settings for the tenant. The goal of this is to allow the application to use this object for defaults per organization such as:
- default workflow for approval
- default icon when there isn't one on products
- more user information ie contact info or something maybe? 

WIP until all complete:
- [x] Add settings field to Tenant object
- [x] Add methods to add/delete/update settings in the hash without having to manually manipulate the json object
- [x] Add API endpoint `/settings` which allows CRUD of the settings for that specific tenant