### PR TITLE
Portfolio share/unshare return 422 if group is not valid

### DIFF
--- a/lib/rbac/utilities.rb
+++ b/lib/rbac/utilities.rb
@@ -5,7 +5,7 @@ module RBAC
         uuids = SortedSet.new
         RBAC::Service.paginate(api, :list_groups, {}).each { |group| uuids << group.uuid }
         missing = @group_uuids - uuids
-        raise ActiveRecord::RecordNotFound, "The following group uuids are missing #{missing.to_a.join(",")}" unless missing.empty?
+        raise Catalog::InvalidParameter, "The following group uuids are missing #{missing.to_a.join(",")}" unless missing.empty?
       end
     end
 

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -419,7 +419,10 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "404": {
-            "description": "The Portfolio Object or or one or more of the groups was not found."
+            "description": "The Portfolio Object was not found."
+          },
+          "422": { 
+            "description": "One or more of the RBAC groups was not found"
           }
         }
       }

--- a/spec/lib/rbac/share_resource_spec.rb
+++ b/spec/lib/rbac/share_resource_spec.rb
@@ -23,7 +23,7 @@ describe RBAC::ShareResource do
     it "raises exception if group id is invalid" do
       allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
       allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return(roles)
-      expect { subject.process }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { subject.process }.to raise_exception(Catalog::InvalidParameter)
     end
   end
 

--- a/spec/lib/rbac/unshare_resource_spec.rb
+++ b/spec/lib/rbac/unshare_resource_spec.rb
@@ -34,7 +34,7 @@ describe RBAC::UnshareResource do
     let(:group_uuids) { %w[1] }
     it "raises exception if group id is invalid" do
       allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
-      expect { subject.process }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { subject.process }.to raise_exception(Catalog::InvalidParameter)
     end
   end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-542

A bug was found that sharing returned 404, while unsharing returned a
422. This fixes the behavior by making the `verify_groups` method raise
 `Catalog::InvalidParameter` instead of `ActiveRecord::RecordNotFound`