### PR TITLE
Comment out the OpenShift control parameter logic.

### DIFF
--- a/app/services/catalog/provider_control_parameters.rb
+++ b/app/services/catalog/provider_control_parameters.rb
@@ -7,13 +7,14 @@ module Catalog
     end
 
     def process
-      source_ref = PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
-      TopologicalInventory.call do |api_instance|
-        # TODO: Temporay till we get this call in the topology service
-        projects = api_instance.list_source_container_projects(source_ref).data
-        update_project_list(project_names(projects))
-        self
-      end
+      # source_ref = PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
+      # TopologicalInventory.call do |api_instance|
+      #   # TODO: Temporary till we get this call in the topology service
+      #   projects = api_instance.list_source_container_projects(source_ref).data
+      #   update_project_list(project_names(projects))
+      #   self
+      # end
+      self
     rescue StandardError => e
       Rails.logger.error("ProviderControlParameters #{e.message}")
       raise

--- a/spec/services/catalog/provider_control_parameters_spec.rb
+++ b/spec/services/catalog/provider_control_parameters_spec.rb
@@ -32,14 +32,14 @@ describe Catalog::ProviderControlParameters do
       data['properties']['namespace']['enum']
     end
 
-    it 'sorts project list' do
+    xit 'sorts project list' do
       expect(namespace_list).to contain_exactly(project1_name, project2_name)
     end
   end
 
   context "invalid portfolio item" do
     let(:params) { 1 }
-    it "raises exception" do
+    xit "raises exception" do
       expect { provider_control_parameters.process }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end


### PR DESCRIPTION
The class will always return an empty data hash for now.

Called from https://github.com/ManageIQ/catalog-api/blob/master/app/controllers/api/v1x0/provider_control_parameters_controller.rb#L6

Since we are not supporting OpenShift catalog items this is not needed right now (was marked as "Temporary") and ultimately needs to move over to be supported through better Topology integration.