### PR TITLE
Update "Jenkinsfile-smoke.groovy" with reference to catalog local configuration file

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -12,5 +12,7 @@ if (env.CHANGE_ID) {
         ocDeployerServiceSets: "catalog,topological-inventory,sources,approval,platform-mq",
         iqePlugins: ["iqe-self-service-portal-plugin"],
         pytestMarker: "catalog_api_smoke",
+        // local settings file
+        configFileCredentialsId: "catalog-config",
     )
 }


### PR DESCRIPTION
Add some reference to the Jenkins secret file, which includes catalog local settings testing attributes.
That will allow the set of fake user headers to catalog API client.