### PR TITLE
Readjust how message is applied to approval_request

### DIFF
--- a/app/controllers/internal/v0/notify_controller.rb
+++ b/app/controllers/internal/v0/notify_controller.rb
@@ -4,11 +4,11 @@ module Internal
       def notify_approval_request
         request_id = params.require(:request_id)
         payload = params.require(:payload)
+        message = params.require(:message)
 
         ActsAsTenant.without_tenant do
-          Catalog::NotifyApprovalRequest.new(request_id, payload).process
+          Catalog::NotifyApprovalRequest.new(request_id, payload, message).process
         end
-
         json_response(nil)
       end
 

--- a/app/services/catalog/notify_approval_request.rb
+++ b/app/services/catalog/notify_approval_request.rb
@@ -4,9 +4,10 @@ module Catalog
 
     attr_reader :notification_object
 
-    def initialize(ref_id, payload)
+    def initialize(ref_id, payload, message)
       @notification_object = ApprovalRequest.find_by(:approval_request_ref => ref_id)
       @payload = payload
+      @message = message
     end
 
     def process
@@ -21,8 +22,7 @@ module Catalog
     private
 
     def request_finished?
-      Rails.logger.info("#request_finished? #{@payload["message"] == EVENT_REQUEST_FINISHED} payload: #{@payload}")
-      @payload["message"] == EVENT_REQUEST_FINISHED
+      @message == EVENT_REQUEST_FINISHED
     end
   end
 end

--- a/spec/services/catalog/notify_approval_request_spec.rb
+++ b/spec/services/catalog/notify_approval_request_spec.rb
@@ -1,5 +1,5 @@
 describe Catalog::NotifyApprovalRequest do
-  let(:subject) { described_class.new(ref_id, payload) }
+  let(:subject) { described_class.new(ref_id, payload['payload'], payload['message']) }
 
   describe "#process" do
     context "when the class is an approval request" do
@@ -8,7 +8,7 @@ describe Catalog::NotifyApprovalRequest do
       let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
       let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123") }
       let(:ref_id) { "123" }
-      let(:payload) { {"decision" => "approved", "reason" => "because", "message" => message} }
+      let(:payload) { { "payload" => {"decision" => "approved", "reason" => "because" }, "message" => message } }
       let(:approval_transition) { instance_double("Catalog::ApprovalTransition") }
 
       before do

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -10,7 +10,7 @@ module ServiceSpecHelper
   end
 
   def original_url
-    "whatever"
+    "http://whatever.com"
   end
 
   def default_request


### PR DESCRIPTION
The message is coming in as a separate key
Reajusted how it comes in and how it is applied once
`request_finished?` is `true`.