### PR TITLE
Update migrate_icons rake task to copy tenant_id so migration runs smoothly

### DIFF
--- a/lib/tasks/migrate_icons.rake
+++ b/lib/tasks/migrate_icons.rake
@@ -20,7 +20,8 @@ namespace :db do
             :data              => icon.data,
             :source_ref        => icon.source_ref,
             :source_id         => icon.source_id,
-            :portfolio_item_id => item.id
+            :portfolio_item_id => item.id,
+            :tenant_id         => item.tenant_id
           )
         end
       end


### PR DESCRIPTION
Pretty simply fix regarding how the icon migration works, I forgot to copy `tenant_id` over to the new icon so literally everything was broken. This will prevent that from happening when we run this on QE/PROD.