### PR TITLE
Various PortfolioItem validation bugs

### DIFF
--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -8,6 +8,11 @@ class PortfolioItem < ApplicationRecord
   has_many :icons, :dependent => :destroy
   belongs_to :portfolio, :optional => true
   validates :service_offering_ref, :name, :display_name, :presence => true
+  validates :favorite_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
+
+  def add_icon(icon)
+    self.icon = icon
+  end
 
   def resolved_workflow_refs
     # TODO: Add lookup to platform workflow ref

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -50,6 +50,15 @@ describe PortfolioItem do
 
     let(:ref) { portfolio_item.send(:item_workflow_ref) }
 
+    around do |example|
+      stub_request(:get, "http://localhost/api/approval/v1.0/workflows/portfolio_item_workflow_ref")
+        .to_return(:status => 200, :body => "", :headers => {"Content-type" => "application/json"})
+
+      with_modified_env(:APPROVAL_URL => "http://localhost") do
+        ManageIQ::API::Common::Request.with_request(default_request) { example.call }
+      end
+    end
+
     context "when the portfolio_item has a workflow_ref" do
       it "returns the portfolio_item's workflow ref" do
         expect(ref).to eq item_workflow_ref

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -3,7 +3,16 @@ describe Catalog::CreateApprovalRequest, :type => :service do
 
   let(:workflow_ref) { "1" }
   let!(:order) { order_item.order }
-  let!(:portfolio_item) { create(:portfolio_item, :workflow_ref => workflow_ref) }
+  let!(:portfolio_item) do
+    stub_request(:get, "http://localhost/api/approval/v1.0/workflows/1")
+      .to_return(:status => 200, :body => "", :headers => {"Content-type" => "application/json"})
+
+    with_modified_env(:APPROVAL_URL => "http://localhost") do
+      ManageIQ::API::Common::Request.with_request(default_request) do
+        create(:portfolio_item, :workflow_ref => workflow_ref)
+      end
+    end
+  end
   let!(:order_item) { create(:order_item, :portfolio_item => portfolio_item) }
 
   let(:approval) { class_double(Approval).as_stubbed_const(:transfer_nested_constants => true) }


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-560

- [x] Passing Non-Boolean "favorite" = "True-as-a-string" or integer 1234 returned 200 instead of 422.
- [x] Passing Non existing "workflow_ref" = "3110" returned 200 instead of 404.
- [x] Passing empty "workflow_ref" = "" returned 200 instead of 404.
- [x] 100% test coverage on approval - #343 