### PR TITLE
We are not using the property and not expecting it to contain values.

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -4,7 +4,6 @@ class OrderItem < ApplicationRecord
 
   validates_presence_of :count
   validates_presence_of :service_parameters
-  validates_presence_of :provider_control_parameters
   validates_presence_of :order_id
   validates_presence_of :service_plan_ref
   validates_presence_of :portfolio_item_id


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-605

Based on https://github.com/ManageIQ/catalog-api/pull/331#discussion_r302323342 we are removing the UI call for `provider_control_parameters` in https://github.com/ManageIQ/catalog-ui/pull/231

With this UI change we also need to drop the validation of the `provider_control_parameters` when creating the `order_item` record.

Note: We default `provider_control_parameters` to an empty hash here https://github.com/ManageIQ/catalog-api/blob/master/app/services/catalog/add_to_order.rb#L18 when creating the `OrderItem`: https://github.com/ManageIQ/catalog-api/blob/master/app/services/catalog/add_to_order.rb#L11.  It seems kind of odd that our default value is invalid.

cc @Hyperkid123 