### PR TITLE
Allow nil service_offering_icon_id when creating a portfolio_item

### DIFF
--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -16,7 +16,7 @@ module ServiceOffering
 
       # Get the fields that we're going to pull over
       @item = PortfolioItem.create!(generate_attributes)
-      @item.icons << create_icon(@service_offering.service_offering_icon_id)
+      @item.icons << create_icon(@service_offering.service_offering_icon_id) if @service_offering.service_offering_icon_id.present?
       self
     rescue StandardError => e
       Rails.logger.error("Service Offering Ref: #{@params[:service_offering_ref]} #{e.message}")

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -47,6 +47,17 @@ describe ServiceOffering::AddToPortfolioItem do
     end
   end
 
+  context "when there is no icon" do
+    let(:topology_service_offering)  { fully_populated_service_offering.tap { |so| so.service_offering_icon_id = nil } }
+
+    it "does not copy over the icon" do
+      ManageIQ::API::Common::Request.with_request(default_request) do
+        result = subject.process
+        expect(result.item.icons.count).to eq 0
+      end
+    end
+  end
+
   context "raises an error" do
     let(:params) { HashWithIndifferentAccess.new(:service_offering_ref => service_offering_ref) }
     it "#process" do


### PR DESCRIPTION
Currently this will explode if the `service_offering_icon_id` is nil since we were assuming all service offerings have icons. This isn't the case and could potentially cause problems in the future. 