### PR TITLE
Remove OpenShift sanitization code and clean up SanitizedParameters spec 

### DIFF
--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -40,29 +40,20 @@ module Catalog
 
     def sanitized_parameters
       svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
-      if service_plan_schema[:properties].present?
-        service_plan_schema[:properties].each_with_object({}) do |(key, attrs), result|
-          value = hide?(key, attrs) ? MASKED_VALUE : svc_params[key]
-          result[attrs[:title]] = value
-        end
-      else
-        service_plan_schema[:schema][:fields].each_with_object({}) do |(field), result|
-          value = hide_ansible?(field) ? MASKED_VALUE : svc_params[field[:name]]
-          result[field[:name]] = value
-        end
+      fields.each_with_object({}) do |field, result|
+        value = mask_value?(field) ? MASKED_VALUE : svc_params[field[:name]]
+        result[field[:name]] = value
       end
     end
 
-    def hide_ansible?(field)
+    def mask_value?(field)
       FILTERED_PARAMS.reduce(field[:type] == "password") do |result, param|
         result || /#{param}/i.match?(field[:name]) || /#{param}/i.match?(field[:label])
       end
     end
 
-    def hide?(key, attrs)
-      FILTERED_PARAMS.reduce(attrs[:format] == "password") do |result, param|
-        result || /#{param}/i.match?(attrs[:title]) || /#{param}/i.match(key)
-      end
+    def fields
+      service_plan_schema.dig(:schema, :fields) || []
     end
   end
 end


### PR DESCRIPTION
After pushing a couple of commits to get the sanitized parameter class working with the ansible schema the spec was in pretty bad shape. This PR just cleans it up and covers both possible cases of ansible/ocp schemas.

JIRA: https://projects.engineering.redhat.com/browse/SSP-623