### PR TITLE
Only set long_description when provided as part of the source_offering

### DIFF
--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -41,8 +41,6 @@ module ServiceOffering
     # If certain fields are empty populate them from the other fields that we do have.
     def populate_missing_fields
       @params[:service_offering_source_ref] = @service_offering.source_id
-      # Fill up empty fields if they're empty with fields we already have, this is really easy with the ||= and subsequent || operators
-      @params[:long_description] ||= @params[:description] || @params[:display_name]
       @params[:display_name] ||= @params[:name]
       @params
     end

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -30,6 +30,17 @@ describe ServiceOffering::AddToPortfolioItem do
         expect(result.item.description).to eq(user_defined_description)
       end
     end
+
+    context "when service_offering does not have a long_description" do
+      let(:topology_service_offering) { fully_populated_service_offering.tap { |so| so.long_description = nil } }
+
+      it "should leave long_description set to nil" do
+        ManageIQ::API::Common::Request.with_request(default_request) do
+          result = subject.process
+          expect(result.item.long_description).to be_nil
+        end
+      end
+    end
   end
 
   context "no user provided params" do


### PR DESCRIPTION
The `long_description` property is meant to contain additional information separate from the `description` property.  This way the smaller "card" view can show just the `description` and the details page would show both `description` and `long_description`.  Therefore it does not need to be duplicated.

You can see an example of the data as it relates to OCP items in the story https://projects.engineering.redhat.com/browse/SSP-128

Having the data duplicated causes the UI to show duplicate strings:
![image](https://user-images.githubusercontent.com/2591569/61995740-6932e880-b05a-11e9-87b2-95a83ded5186.png)
