### PR TITLE
Remove icon validation requiring data field

### DIFF
--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -16,7 +16,10 @@ module ServiceOffering
 
       # Get the fields that we're going to pull over
       @item = PortfolioItem.create!(generate_attributes)
-      @item.icons << create_icon(@service_offering.service_offering_icon_id) if @service_offering.service_offering_icon_id.present?
+
+      icon = create_icon(@service_offering.service_offering_icon_id) if @service_offering.service_offering_icon_id.present?
+      @item.icons << icon unless icon.nil?
+
       self
     rescue StandardError => e
       Rails.logger.error("Service Offering Ref: #{@params[:service_offering_ref]} #{e.message}")
@@ -47,6 +50,8 @@ module ServiceOffering
 
     def create_icon(icon_id)
       service_offering_icon = TopologicalInventory.call { |topo| topo.show_service_offering_icon(icon_id) }
+      return if service_offering_icon.data.nil?
+
       Icon.create!(
         :data       => service_offering_icon.data,
         :source_ref => service_offering_icon.source_ref,

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -69,6 +69,17 @@ describe ServiceOffering::AddToPortfolioItem do
     end
   end
 
+  context 'when the icon has no data' do
+    let(:service_offering_icon) { fully_populated_service_offering_icon.tap { |icon| icon.data = nil } }
+
+    it "does not copy over the icon" do
+      ManageIQ::API::Common::Request.with_request(default_request) do
+        result = subject.process
+        expect(result.item.icons.count).to eq 0
+      end
+    end
+  end
+
   context "raises an error" do
     let(:params) { HashWithIndifferentAccess.new(:service_offering_ref => service_offering_ref) }
     it "#process" do


### PR DESCRIPTION
Found during testing that `service_offering_icon` doesn't always have the `:data` field even though that is what contains the svg data. Removing the validation since it's not required on the topology core side as well.

EDIT: Changed the way we handle this on the catalog side, we now don't import the icon if the `:data` field is null since that can exist. 

bug: https://projects.engineering.redhat.com/browse/SSP-635