### PR TITLE
Raise our own "UncancelableError" when Approval errors on cancel_order

### DIFF
--- a/app/services/catalog/cancel_order.rb
+++ b/app/services/catalog/cancel_order.rb
@@ -35,7 +35,7 @@ module Catalog
     def raise_uncancelable_error
       error_message = "Order #{@order.id} is not cancelable in its current state: #{@order.state}"
       Rails.logger.error(error_message)
-      raise Catalog::OrderUncancelable.new(error_message)
+      raise Catalog::OrderUncancelable, error_message
     end
   end
 end

--- a/app/services/catalog/cancel_order.rb
+++ b/app/services/catalog/cancel_order.rb
@@ -17,6 +17,9 @@ module Catalog
       end
 
       self
+    rescue Catalog::ApprovalError => e
+      Rails.logger.error("Approval error while canceling order: #{e.message}")
+      raise uncancelable_error
     end
 
     private

--- a/app/services/catalog/cancel_order.rb
+++ b/app/services/catalog/cancel_order.rb
@@ -1,6 +1,6 @@
 module Catalog
   class CancelOrder
-    UNCANCELABLE_STATES = %w[Completed Failed].freeze
+    UNCANCELABLE_STATES = %w[Completed Failed Ordered].freeze
     attr_reader :order
 
     def initialize(order_id)
@@ -8,7 +8,7 @@ module Catalog
     end
 
     def process
-      raise uncancelable_error if UNCANCELABLE_STATES.include?(@order.state)
+      raise_uncancelable_error if UNCANCELABLE_STATES.include?(@order.state)
 
       approval_requests.each do |approval_request|
         Approval.call_action_api do |api|
@@ -19,7 +19,7 @@ module Catalog
       self
     rescue Catalog::ApprovalError => e
       Rails.logger.error("Approval error while canceling order: #{e.message}")
-      raise uncancelable_error
+      raise_uncancelable_error
     end
 
     private
@@ -32,8 +32,10 @@ module Catalog
       @canceled_action ||= ApprovalApiClient::ActionIn.new(:operation => "cancel")
     end
 
-    def uncancelable_error
-      Catalog::OrderUncancelable.new("Order #{@order.id} is not cancelable in its current state")
+    def raise_uncancelable_error
+      error_message = "Order #{@order.id} is not cancelable in its current state: #{@order.state}"
+      Rails.logger.error(error_message)
+      raise Catalog::OrderUncancelable.new(error_message)
     end
   end
 end

--- a/spec/services/catalog/cancel_order_spec.rb
+++ b/spec/services/catalog/cancel_order_spec.rb
@@ -21,7 +21,7 @@ describe Catalog::CancelOrder do
       let(:state) { "Completed" }
 
       it "raises an error" do
-        expect { subject.process }.to raise_exception(Catalog::OrderUncancelable, "Order #{order.id} is not cancelable in its current state")
+        expect { subject.process }.to raise_exception(Catalog::OrderUncancelable, "Order #{order.id} is not cancelable in its current state: #{order.state}")
       end
     end
 
@@ -29,7 +29,15 @@ describe Catalog::CancelOrder do
       let(:state) { "Failed" }
 
       it "raises an error" do
-        expect { subject.process }.to raise_exception(Catalog::OrderUncancelable, "Order #{order.id} is not cancelable in its current state")
+        expect { subject.process }.to raise_exception(Catalog::OrderUncancelable, "Order #{order.id} is not cancelable in its current state: #{order.state}")
+      end
+    end
+
+    describe "when the state of the order is Ordered" do
+      let(:state) { "Ordered" }
+
+      it "raises an error" do
+        expect { subject.process }.to raise_exception(Catalog::OrderUncancelable, "Order #{order.id} is not cancelable in its current state: #{order.state}")
       end
     end
 

--- a/spec/services/catalog/cancel_order_spec.rb
+++ b/spec/services/catalog/cancel_order_spec.rb
@@ -38,12 +38,24 @@ describe Catalog::CancelOrder do
       let(:cancel_order_url) { "http://localhost/api/approval/v1.0/requests/#{approval_request.id}/actions" }
 
       before do
-        stub_request(:post, cancel_order_url).with(:body => {"operation" => "cancel"})
+        stub_request(:post, cancel_order_url).with(:body => {"operation" => "cancel"}).to_return(api_response)
       end
 
-      it "calls the approval api" do
-        subject.process
-        expect(a_request(:post, cancel_order_url).with(:body => {"operation" => "cancel"})).to have_been_made
+      context "when the request returns a 200" do
+        let(:api_response) { {:status => 200} }
+
+        it "calls the approval api" do
+          subject.process
+          expect(a_request(:post, cancel_order_url).with(:body => {"operation" => "cancel"})).to have_been_made
+        end
+      end
+
+      context "when the request returns a 500" do
+        let(:api_response) { {:status => 500} }
+
+        it "rescues the exception" do
+          expect { subject.process }.to raise_exception(Catalog::OrderUncancelable)
+        end
       end
     end
   end


### PR DESCRIPTION
While this doesn't solve the problem of orders not being able to be canceled, it should stop the 500 errors.

@syncrou Please Review