### PR TITLE
Rake task to remove rbac roles for discarded portfolios

### DIFF
--- a/lib/tasks/porfolios.rake
+++ b/lib/tasks/porfolios.rake
@@ -31,9 +31,9 @@ namespace :portfolios do
           role.name.start_with?(role_name_prefix)
         end
 
-        matching_roles.each do |role|
-          puts "Deleting role #{role.name}"
-          RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+        RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+          matching_roles.each do |role|
+            puts "Deleting role #{role.name}"
             api.delete_role(role.uuid)
           end
         end

--- a/lib/tasks/porfolios.rake
+++ b/lib/tasks/porfolios.rake
@@ -24,7 +24,7 @@ namespace :portfolios do
 
   def delete_roles(current_user)
     roles = fetch_roles
-    ActsAsTenant.with_tenant(current_tenant(current_user)) do  
+    ActsAsTenant.with_tenant(current_tenant(current_user)) do
       Portfolio.with_discarded.discarded.each do |portfolio|
         role_name_prefix = "catalog-portfolios-#{portfolio.id}-"
         matching_roles = roles.select do |role|

--- a/lib/tasks/porfolios.rake
+++ b/lib/tasks/porfolios.rake
@@ -1,0 +1,39 @@
+require 'rake'
+
+namespace :portfolio do
+  desc "Remove RBAC roles for discarded portfolios"
+  task :remove_discarded_rbac => :environment do
+    raise "Please provide a user yaml file" unless ENV['USER_FILE']
+    request = create_request(ENV['USER_FILE'])
+    ManageIQ::API::Common::Request.with_request(request) do
+      roles = []
+      opts = { limit: 500, name: "catalog-portfolios" }
+
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+        roles = RBAC::Service.paginate(api, :list_roles, opts).to_a
+      end
+
+      Portfolio.with_discarded.each do |portfolio|
+        next unless portfolio.discarded?
+
+        role_name_prefix = "catalog-portfolios-#{portfolio.id}-"
+        matching_roles = roles.select do |role| 
+          role.name.start_with?(role_name_prefix)
+        end
+
+        matching_roles.each do |role|
+          puts "Deleting role #{role.name}"
+          RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+            api.delete_role(role.uuid)
+          end
+        end
+      end
+    end
+  end
+
+  def create_request(user_file)
+    raise "File #{user_file} not found" unless File.exist?(user_file)
+    user = YAML.load_file(user_file)
+    {:headers => {'x-rh-identity' => Base64.strict_encode64(user.to_json)}, :original_url => '/'}
+  end
+end

--- a/lib/tasks/porfolios.rake
+++ b/lib/tasks/porfolios.rake
@@ -1,22 +1,31 @@
 require 'rake'
 
-namespace :portfolio do
+namespace :portfolios do
   desc "Remove RBAC roles for discarded portfolios"
   task :remove_discarded_rbac => :environment do
     raise "Please provide a user yaml file" unless ENV['USER_FILE']
 
     request = create_request(ENV['USER_FILE'])
-    ManageIQ::API::Common::Request.with_request(request) do
-      roles = []
-      opts = { :limit => 500, :name => "catalog-portfolios" }
+    ManageIQ::API::Common::Request.with_request(request) do |current|
+      delete_roles(current.user)
+    end
+  end
 
-      RBAC::Service.call(RBACApiClient::RoleApi) do |api|
-        roles = RBAC::Service.paginate(api, :list_roles, opts).to_a
-      end
+  def create_request(user_file)
+    raise "File #{user_file} not found" unless File.exist?(user_file)
 
-      Portfolio.with_discarded.each do |portfolio|
-        next unless portfolio.discarded?
+    user = YAML.load_file(user_file)
+    {:headers => {'x-rh-identity' => Base64.strict_encode64(user.to_json)}, :original_url => '/'}
+  end
 
+  def current_tenant(current_user)
+    Tenant.find_by!(:external_tenant => current_user.tenant)
+  end
+
+  def delete_roles(current_user)
+    roles = fetch_roles
+    ActsAsTenant.with_tenant(current_tenant(current_user)) do  
+      Portfolio.with_discarded.discarded.each do |portfolio|
         role_name_prefix = "catalog-portfolios-#{portfolio.id}-"
         matching_roles = roles.select do |role|
           role.name.start_with?(role_name_prefix)
@@ -32,10 +41,10 @@ namespace :portfolio do
     end
   end
 
-  def create_request(user_file)
-    raise "File #{user_file} not found" unless File.exist?(user_file)
-
-    user = YAML.load_file(user_file)
-    {:headers => {'x-rh-identity' => Base64.strict_encode64(user.to_json)}, :original_url => '/'}
+  def fetch_roles
+    opts = { :limit => 500, :name => "catalog-portfolios" }
+    RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+      RBAC::Service.paginate(api, :list_roles, opts).to_a
+    end
   end
 end

--- a/lib/tasks/porfolios.rake
+++ b/lib/tasks/porfolios.rake
@@ -4,10 +4,11 @@ namespace :portfolio do
   desc "Remove RBAC roles for discarded portfolios"
   task :remove_discarded_rbac => :environment do
     raise "Please provide a user yaml file" unless ENV['USER_FILE']
+
     request = create_request(ENV['USER_FILE'])
     ManageIQ::API::Common::Request.with_request(request) do
       roles = []
-      opts = { limit: 500, name: "catalog-portfolios" }
+      opts = { :limit => 500, :name => "catalog-portfolios" }
 
       RBAC::Service.call(RBACApiClient::RoleApi) do |api|
         roles = RBAC::Service.paginate(api, :list_roles, opts).to_a
@@ -17,7 +18,7 @@ namespace :portfolio do
         next unless portfolio.discarded?
 
         role_name_prefix = "catalog-portfolios-#{portfolio.id}-"
-        matching_roles = roles.select do |role| 
+        matching_roles = roles.select do |role|
           role.name.start_with?(role_name_prefix)
         end
 
@@ -33,6 +34,7 @@ namespace :portfolio do
 
   def create_request(user_file)
     raise "File #{user_file} not found" unless File.exist?(user_file)
+
     user = YAML.load_file(user_file)
     {:headers => {'x-rh-identity' => Base64.strict_encode64(user.to_json)}, :original_url => '/'}
   end


### PR DESCRIPTION
usage:

Create a user.yml file (a sample file is provided under data directory) with the appropriate account_number, username, email and org_id. e.g if the file created is /tmp/user.yml

**_export USER_FILE=/tmp/user.yml
rake portfolios:remove_discarded_rbac_**

JIRA https://projects.engineering.redhat.com/browse/SSP-654