### PR TITLE
Fix OpenAPI spec: require portfolio item name and not require portfolio description

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1875,8 +1875,7 @@
       "Portfolio": {
         "type": "object",
         "required": [
-          "name",
-          "description"
+          "name"
         ],
         "properties": {
           "id": {
@@ -2015,6 +2014,9 @@
       },
       "PortfolioItem": {
         "type": "object",
+        "required": [
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "string",


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-168

Simple PR to add a couple fixes to the OpenAPI spec.

1. Require name on PortfolioItem
2. Remove requirement of description on Portfolio