### PR TITLE
Process Topology Task context as an object instead of string

### DIFF
--- a/app/services/catalog/update_order_item.rb
+++ b/app/services/catalog/update_order_item.rb
@@ -33,7 +33,7 @@ module Catalog
     def fetch_external_url
       TopologicalInventory.call do |api_instance|
         task = api_instance.show_task(@payload["task_id"])
-        @service_instance_id = JSON.parse(task.context)["service_instance"]["id"]
+        @service_instance_id = task.context[:service_instance][:id]
         service_instance = api_instance.show_service_instance(@service_instance_id)
         raise ServiceInstanceWithoutExternalUrl if service_instance.external_url.nil?
         service_instance.external_url

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -38,7 +38,7 @@ describe Catalog::UpdateOrderItem do
 
       context "when the status of the task is ok" do
         let(:status) { "ok" }
-        let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => service_instance_id}}.to_json) }
+        let(:task) { TopologicalInventoryApiClient::Task.new(:context => {:service_instance => {:id => service_instance_id}}) }
         let(:service_instance) { TopologicalInventoryApiClient::ServiceInstance.new(:external_url => "external url") }
         let(:service_instance_no_external_url) { TopologicalInventoryApiClient::ServiceInstance.new }
 


### PR DESCRIPTION
Based on Topology changes from https://github.com/ManageIQ/topological_inventory-ansible_tower/pull/20

Task object from Topology use to return the `context` property as a string.

Before:
```yaml
{
  context: "{"service_instance":{"source_id":"352","source_ref":197,"id":"2058","url":"http://172.30.160.43:8080/api/topological-inventory/v1.0/service_instances/2058"},"remote_status":"successful"}",
  created_at: "2019-08-06T21:20:45Z",
  id: "119",
  state: "completed",
  status: "ok",
  updated_at: "2019-08-06T21:22:50Z"
}
```

After:
```yaml
{
  context: {
    remote_status: "successful",
    service_instance: {
      id: "2061",
      url: "http://172.30.160.43:8080/api/topological-inventory/v1.0/service_instances/2061",
      source_id: "352",
      source_ref: 199
    }
  },
  created_at: "2019-08-09T16:34:07Z",
  id: "120",
  state: "completed",
  status: "ok",
  updated_at: "2019-08-09T16:34:43Z"
}
```