### PR TITLE
Add 'request_canceled' to list of acceptable completed event states

### DIFF
--- a/app/services/catalog/notify_approval_request.rb
+++ b/app/services/catalog/notify_approval_request.rb
@@ -1,6 +1,8 @@
 module Catalog
   class NotifyApprovalRequest
     EVENT_REQUEST_FINISHED = "request_finished".freeze
+    EVENT_REQUEST_CANCELED = "request_canceled".freeze
+    COMPLETED_EVENTS = [EVENT_REQUEST_FINISHED, EVENT_REQUEST_CANCELED].freeze
 
     attr_reader :notification_object
 
@@ -11,7 +13,7 @@ module Catalog
     end
 
     def process
-      return self unless request_finished?
+      return self unless request_complete?
 
       @notification_object.update(:state => @payload["decision"], :reason => @payload["reason"])
       Catalog::ApprovalTransition.new(@notification_object.order_item.id).process
@@ -21,8 +23,8 @@ module Catalog
 
     private
 
-    def request_finished?
-      @message == EVENT_REQUEST_FINISHED
+    def request_complete?
+      COMPLETED_EVENTS.include?(@message)
     end
   end
 end

--- a/app/services/catalog/notify_approval_request.rb
+++ b/app/services/catalog/notify_approval_request.rb
@@ -15,7 +15,7 @@ module Catalog
     def process
       return self unless request_complete?
 
-      @notification_object.update(:state => @payload["decision"], :reason => @payload["reason"])
+      update_state
       Catalog::ApprovalTransition.new(@notification_object.order_item.id).process
 
       self
@@ -25,6 +25,17 @@ module Catalog
 
     def request_complete?
       COMPLETED_EVENTS.include?(@message)
+    end
+
+    def update_state
+      case @message
+      when EVENT_REQUEST_CANCELED
+        state = "canceled"
+      when EVENT_REQUEST_FINISHED
+        state = @payload["decision"]
+      end
+
+      @notification_object.update(:state => state, :reason => @payload["reason"])
     end
   end
 end

--- a/spec/services/catalog/notify_approval_request_spec.rb
+++ b/spec/services/catalog/notify_approval_request_spec.rb
@@ -8,7 +8,6 @@ describe Catalog::NotifyApprovalRequest do
       let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
       let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123") }
       let(:ref_id) { "123" }
-      let(:payload) { {"payload" => {"decision" => decision, "reason" => "because" }, "message" => message} }
       let(:approval_transition) { instance_double("Catalog::ApprovalTransition") }
 
       before do
@@ -19,7 +18,7 @@ describe Catalog::NotifyApprovalRequest do
       end
 
       context "when the message is request_finished" do
-        let(:decision) { "approved" }
+        let(:payload) { {"payload" => {"decision" => "approved", "reason" => "because"}, "message" => message} }
         let(:message) { "request_finished" }
 
         it "updates the state" do
@@ -41,7 +40,7 @@ describe Catalog::NotifyApprovalRequest do
       end
 
       context "when the message is request_canceled" do
-        let(:decision) { "canceled" }
+        let(:payload) { {"payload" => {"reason" => "because"}, "message" => message} }
         let(:message) { "request_canceled" }
 
         it "updates the state" do
@@ -63,7 +62,7 @@ describe Catalog::NotifyApprovalRequest do
       end
 
       context "when the message is anything else" do
-        let(:decision) { "approved" }
+        let(:payload) { {"payload" => {"decision" => "approved", "reason" => "because"}, "message" => message} }
         let(:message) { "not_request_finished" }
 
         it "does not update the state" do

--- a/spec/services/catalog/notify_approval_request_spec.rb
+++ b/spec/services/catalog/notify_approval_request_spec.rb
@@ -8,7 +8,7 @@ describe Catalog::NotifyApprovalRequest do
       let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
       let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123") }
       let(:ref_id) { "123" }
-      let(:payload) { { "payload" => {"decision" => "approved", "reason" => "because" }, "message" => message } }
+      let(:payload) { {"payload" => {"decision" => decision, "reason" => "because" }, "message" => message} }
       let(:approval_transition) { instance_double("Catalog::ApprovalTransition") }
 
       before do
@@ -19,6 +19,7 @@ describe Catalog::NotifyApprovalRequest do
       end
 
       context "when the message is request_finished" do
+        let(:decision) { "approved" }
         let(:message) { "request_finished" }
 
         it "updates the state" do
@@ -39,7 +40,30 @@ describe Catalog::NotifyApprovalRequest do
         end
       end
 
+      context "when the message is request_canceled" do
+        let(:decision) { "canceled" }
+        let(:message) { "request_canceled" }
+
+        it "updates the state" do
+          expect(approval_request.state).to eq("canceled")
+        end
+
+        it "updates the reason" do
+          expect(approval_request.reason).to eq("because")
+        end
+
+        it "delegates to the approval transition" do
+          expect(approval_transition).to have_received(:process)
+        end
+
+        it "returns the notify object" do
+          expect(@return_value.class).to eq(Catalog::NotifyApprovalRequest)
+          expect(@return_value.notification_object).to eq(approval_request)
+        end
+      end
+
       context "when the message is anything else" do
+        let(:decision) { "approved" }
         let(:message) { "not_request_finished" }
 
         it "does not update the state" do


### PR DESCRIPTION
`Approval` will send a kafka message after a cancel event with the message of `"request_canceled"` instead of `"request_finished"`, but currently the approval notification logic only handles the event if the message is `"request_finished"`. This should fix that :)

@syncrou Please Review