### PR TITLE
Check for Catalog Administrator role before allowing access to Settings API

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -36,6 +36,12 @@ module Api
           end
         end
 
+        def role_check(role)
+          return unless RBAC::Access.enabled?
+
+          raise Catalog::NotAuthorized unless RBAC::Roles.assigned_role?(role)
+        end
+
         private
 
         def permission_format_check(permissions)
@@ -52,13 +58,6 @@ module Api
 
         def invalid_parameter(str)
           raise Catalog::InvalidParameter, str
-        end
-
-        def catalog_admin_check
-          return unless RBAC::Access.enabled?
-
-          access_obj = RBAC::Access.new("portfolios", "write").process
-          raise Catalog::NotAuthorized unless access_obj.catalog_admin?
         end
       end
     end

--- a/app/controllers/api/v1x0/settings_controller.rb
+++ b/app/controllers/api/v1x0/settings_controller.rb
@@ -1,7 +1,9 @@
 module Api
   module V1x0
     class SettingsController < ApplicationController
-      before_action :catalog_admin_check
+      before_action do
+        role_check("Catalog Administrator")
+      end
 
       def index
         settings = Catalog::TenantSettings.new(tenant)

--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -36,11 +36,6 @@ module RBAC
       @ids.include?('*') ? false : owner_scope_filter?
     end
 
-    def catalog_admin?
-      generate_ids
-      @ids.include?('*')
-    end
-
     def self.enabled?
       ENV['BYPASS_RBAC'].blank?
     end

--- a/lib/rbac/roles.rb
+++ b/lib/rbac/roles.rb
@@ -40,11 +40,11 @@ module RBAC
     end
 
     def self.assigned_role?(role_name)
-      opts = { :limit => 100,
+      opts = { :name  => role_name,
                :scope => 'principal' }
 
       RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
-        RBAC::Service.paginate(api_instance, :list_roles, opts).any? { |role| role.name == role_name }
+        RBAC::Service.paginate(api_instance, :list_roles, opts).count.positive?
       end
     end
 

--- a/lib/rbac/roles.rb
+++ b/lib/rbac/roles.rb
@@ -39,6 +39,15 @@ module RBAC
       end
     end
 
+    def self.assigned_role?(role_name)
+      opts = { :limit => 100,
+               :scope => 'principal' }
+
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+        RBAC::Service.paginate(api_instance, :list_roles, opts).any? { |role| role.name == role_name }
+      end
+    end
+
     private
 
     def load(prefix)

--- a/spec/lib/rbac/roles_spec.rb
+++ b/spec/lib/rbac/roles_spec.rb
@@ -1,0 +1,47 @@
+describe RBAC::Roles do
+  let(:opts) { {:name => 'Catalog Administrator', :scope => 'principal'} }
+  let(:response_headers) { {"Content-Type" => 'application/json'} }
+  let(:catalog_admin) do
+    { :data => data, :meta => { :count => count } }
+  end
+
+  around do |example|
+    with_modified_env(:RBAC_URL => "http://localhost") do
+      ManageIQ::API::Common::Request.with_request(default_request) { example.call }
+    end
+  end
+
+  before do
+    stub_request(:get, "http://localhost/api/rbac/v1/roles/?limit=10&name=Catalog%20Administrator&offset=0&scope=principal")
+      .to_return(:status  => 200,
+                 :body    => catalog_admin.to_json,
+                 :headers => response_headers)
+  end
+
+  describe "#self.assigned_role?" do
+    let(:assigned_role) { described_class.assigned_role?("Catalog Administrator") }
+
+    context "when the role exists" do
+      let(:data) do
+        [{
+          :name        => "Catalog Administrator",
+          :description => "A catalog administrator roles grants read, write and order permissions"
+        }]
+      end
+      let(:count) { 1 }
+
+      it "returns true for assigned_role" do
+        expect(assigned_role).to be_truthy
+      end
+    end
+
+    context "when the role does not exist" do
+      let(:data) { [] }
+      let(:count) { 0 }
+
+      it "returns false for assigned_role" do
+        expect(assigned_role).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -7,16 +7,10 @@ describe 'Settings API' do
            })
   end
   let(:retreived_tenant) { Tenant.find(tenant.id) }
-  let(:rbac) { instance_double(RBAC::Access) }
-
-  before do
-    allow(RBAC::Access).to receive(:new).and_return(rbac)
-    allow(rbac).to receive(:process).and_return(rbac)
-  end
 
   context "when the user is a catalog admin" do
     before do
-      allow(rbac).to receive(:catalog_admin?).and_return(true)
+      allow(RBAC::Roles).to receive(:assigned_role?).and_return(true)
     end
 
     describe "#index" do
@@ -104,7 +98,7 @@ describe 'Settings API' do
 
   context "when the user is not a catalog admin" do
     before do
-      allow(rbac).to receive(:catalog_admin?).and_return(false)
+      allow(RBAC::Roles).to receive(:assigned_role?).and_return(false)
     end
 
     it "does not allow any operations" do

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -9,9 +9,7 @@ describe 'Settings API' do
   let(:retreived_tenant) { Tenant.find(tenant.id) }
 
   context "when the user is a catalog admin" do
-    before do
-      allow(RBAC::Roles).to receive(:assigned_role?).and_return(true)
-    end
+    before { allow(RBAC::Roles).to receive(:assigned_role?).with("Catalog Administrator").and_return(true) }
 
     describe "#index" do
       before { get "#{api}/settings", :headers => default_headers }
@@ -97,9 +95,7 @@ describe 'Settings API' do
   end
 
   context "when the user is not a catalog admin" do
-    before do
-      allow(RBAC::Roles).to receive(:assigned_role?).and_return(false)
-    end
+    before { allow(RBAC::Roles).to receive(:assigned_role?).with("Catalog Administrator").and_return(false) }
 
     it "does not allow any operations" do
       get "#{api}/settings", :headers => default_headers


### PR DESCRIPTION
Fixes #362 

When doing the initial work for accessing the Settings API the `list_roles` function didn't exist (or I didn't know where it was, or maybe it was only in CI and not in the other environments). After discussing with the RBAC team they agreed to implement it in all environments so we can properly check when a user has certain roles. 

This PR changes out the check for Catalog Admin (which wasn't an actual role check) and implements a call to RBAC to retrieve roles and make sure the user has the "Catalog Administrator" role. 