### PR TITLE
Bug fix for invalid data type in permissions and group_uuids

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -22,13 +22,12 @@ module Api
 
         def permission_check(verb, klass = controller_name.classify.constantize)
           return unless RBAC::Access.enabled?
+
           access_obj = RBAC::Access.new(klass.table_name, verb).process
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
         end
 
         def permission_array_check(permissions)
-          return unless RBAC::Access.enabled?
-
           if !permissions.kind_of?(Array)
             invalid_parameter('Permission should be an array')
           elsif permissions.blank? || permissions.any?(&:blank?)
@@ -39,9 +38,8 @@ module Api
         private
 
         def permission_format_check(permissions)
-          return unless RBAC::Access.enabled?
-
           permissions.each do |perm|
+            invalid_parameter("Permission should be : delimited and contain app_name:resource:verb, where verb has to be one of #{VALID_RESOURCE_VERBS}") unless perm.kind_of?(String)
             perm_list = perm.split(':')
             invalid_parameter("Permission should be : delimited and contain app_name:resource:verb, where verb has to be one of #{VALID_RESOURCE_VERBS}") unless perm_list.length == 3
             invalid_parameter("Permission app_name should be catalog") unless perm_list.first == 'catalog'

--- a/app/controllers/api/v1x0/mixins/validation_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/validation_mixin.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1x0
+    module Mixins
+      module ValidationMixin
+        def group_id_array_check(uuids)
+          if !uuids.kind_of?(Array)
+            invalid_parameter('Group should be an array')
+          elsif uuids.blank? || uuids.any?(&:blank?)
+            invalid_parameter('Group should not be empty')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_action :only => %i[share unshare] do
         permission_array_check(params.require(:permissions))
         permission_format_check(params.require(:permissions))
+        group_id_array_check(params.require(:group_uuids))
       end
 
       before_action :only => %i[copy] do
@@ -105,6 +106,14 @@ module Api
 
       def portfolio_copy_params
         params.permit(:portfolio_id, :portfolio_name)
+      end
+
+      def group_id_array_check(uuids)
+        if !uuids.kind_of?(Array)
+          invalid_parameter('Group should be an array')
+        elsif uuids.blank? || uuids.any?(&:blank?)
+          invalid_parameter('Group should not be empty')
+        end
       end
     end
   end

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1x0
     class PortfoliosController < ApplicationController
       include Api::V1x0::Mixins::IndexMixin
+      include Api::V1x0::Mixins::ValidationMixin
 
       before_action :write_access_check, :only => %i(add_portfolio_item_to_portfolio create update destroy)
       before_action :read_access_check, :only => %i(show)
@@ -108,13 +109,6 @@ module Api
         params.permit(:portfolio_id, :portfolio_name)
       end
 
-      def group_id_array_check(uuids)
-        if !uuids.kind_of?(Array)
-          invalid_parameter('Group should be an array')
-        elsif uuids.blank? || uuids.any?(&:blank?)
-          invalid_parameter('Group should not be empty')
-        end
-      end
     end
   end
 end

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -108,7 +108,6 @@ module Api
       def portfolio_copy_params
         params.permit(:portfolio_id, :portfolio_name)
       end
-
     end
   end
 end

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -283,7 +283,6 @@ describe 'Portfolios API' do
     end
 
     shared_examples_for "#shared_test" do
-      include_context "sharing_objects"
       it "portfolio" do
         with_modified_env :APP_NAME => app_name do
           options = {:app_name      => app_name,
@@ -291,18 +290,20 @@ describe 'Portfolios API' do
                      :resource_name => 'portfolios',
                      :permissions   => permissions,
                      :group_uuids   => group_uuids}
-          expect(RBAC::ShareResource).to receive(:new).with(options).and_return(dummy)
-          post "#{api}/portfolios/#{portfolio.id}/share", :params => attributes, :headers => default_headers
+          allow(RBAC::ShareResource).to receive(:new).with(options).and_return(dummy)
+          post "#{api}/portfolios/#{portfolio.id}/share", :params => attributes, :headers => default_headers, :as => :json
           expect(response).to have_http_status(http_status)
         end
       end
     end
 
     context 'share' do
+      include_context "sharing_objects"
       it_behaves_like "#shared_test"
     end
 
     context 'bad permissions' do
+      include_context "sharing_objects"
       let(:http_status) { '422' }
 
       context 'invalid verb in permissions' do
@@ -317,6 +318,11 @@ describe 'Portfolios API' do
 
       context 'invalid object in permissions' do
         let(:permissions) { %w[catalog:bad:read] }
+        it_behaves_like "#shared_test"
+      end
+
+      context 'invalid object type in permissions' do
+        let(:permissions) { [123] }
         it_behaves_like "#shared_test"
       end
     end

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -325,6 +325,16 @@ describe 'Portfolios API' do
         let(:permissions) { [123] }
         it_behaves_like "#shared_test"
       end
+
+      context 'invalid group uuids, empty array' do
+        let(:group_uuids) { [] }
+        it_behaves_like "#shared_test"
+      end
+
+      context 'invalid group uuids, data type' do
+        let(:group_uuids) { "fred" }
+        it_behaves_like "#shared_test"
+      end
     end
 
     context 'unshare' do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-539

When the permissions are sent as an integer the server would
try to split it and raise an exception.
Fixed the include_context
Use the :as => :json for the post requests to preserve the datatype