### PR TITLE
Swapped approval_request id attribute for approval_request_ref

### DIFF
--- a/app/services/catalog/cancel_order.rb
+++ b/app/services/catalog/cancel_order.rb
@@ -12,7 +12,7 @@ module Catalog
 
       approval_requests.each do |approval_request|
         Approval.call_action_api do |api|
-          api.create_action_by_request(approval_request.first.id, canceled_action)
+          api.create_action_by_request(approval_request.first.approval_request_ref, canceled_action)
         end
       end
 

--- a/spec/services/catalog/cancel_order_spec.rb
+++ b/spec/services/catalog/cancel_order_spec.rb
@@ -43,7 +43,7 @@ describe Catalog::CancelOrder do
 
     describe "when the state of the order is anything else" do
       let(:state) { "Pending" }
-      let(:cancel_order_url) { "http://localhost/api/approval/v1.0/requests/#{approval_request.id}/actions" }
+      let(:cancel_order_url) { "http://localhost/api/approval/v1.0/requests/#{approval_request.approval_request_ref}/actions" }
 
       before do
         stub_request(:post, cancel_order_url).with(:body => {"operation" => "cancel"}).to_return(api_response)


### PR DESCRIPTION
Resolves the issue where the wrong attribute was passed to Approval for use in canceling an order.

Jira: https://projects.engineering.redhat.com/browse/SSP-678