### PR TITLE
[WIP] Catalog group and policy seeding

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,10 @@ class ApplicationController < ActionController::API
       if current.required_auth?
         raise ManageIQ::API::Common::EntitlementError, "User not Entitled" unless check_entitled(current.entitlement)
 
-        ActsAsTenant.with_tenant(current_tenant(current.user)) { yield }
+        ActsAsTenant.with_tenant(current_tenant(current.user)) do
+          validate_rbac_groups(current.user)
+          yield
+        end
       else
         ActsAsTenant.without_tenant { yield }
       end
@@ -30,5 +33,12 @@ class ApplicationController < ActionController::API
     required_entitlements = %i[hybrid_cloud?]
 
     required_entitlements.map { |e| entitlement.send(e) }.all?
+  end
+
+  def validate_rbac_groups(user)
+    Thread.new do
+      return unless user.org_admin?
+      RBAC::GroupSeed.new(user).process
+    end
   end
 end

--- a/app/services/rbac/group_seed.rb
+++ b/app/services/rbac/group_seed.rb
@@ -1,0 +1,19 @@
+module RBAC
+  class GroupSeed
+    $seeded_tenants = {}
+
+    def initialize(user)
+      @user = user
+    end
+
+    def process
+      self.tap do
+        return unless @user.org_admin?
+        return if $seeded_tenants[ActsAsTenant.current_tenant.external_tenant]
+
+        RBAC::Seed.new(Rails.root.join('data', 'rbac_catalog_seed.yml')).process
+        $seeded_tenants[ActsAsTenant.current_tenant.external_tenant] = true
+      end
+    end
+  end
+end

--- a/lib/rbac/seed.rb
+++ b/lib/rbac/seed.rb
@@ -1,13 +1,13 @@
 require 'rbac-api-client'
 module RBAC
   class Seed
-    def initialize(seed_file, user_file)
+    def initialize(seed_file, user_file=nil)
       @acl_data = YAML.load_file(seed_file)
-      @request = create_request(user_file)
+      @request = create_request(user_file) if user_file
     end
 
     def process
-      ManageIQ::API::Common::Request.with_request(@request) do
+      with_request do
         create_groups
         create_roles
         create_policies
@@ -15,6 +15,14 @@ module RBAC
     end
 
     private
+
+    def with_request
+      if @request
+        ManageIQ::API::Common::Request.with_request(@request) { yield }
+      else
+        yield
+      end
+    end
 
     def create_groups
       current = current_groups


### PR DESCRIPTION
That is an early start at trying to seed groups if the user is an org_admin and the groups do not already exist in RBAC.

I considered moving the controller work into a before or after action callback.  Also, the code does not currently check if the Groups exist before calling the existing seeding logic.  The `Thread.new` is optional as well.

Per the linked Jira issue the suggested names are "Default Catalog Administrators" and "Default Catalog Users". 

Note: The code as-is does not currently work.

https://projects.engineering.redhat.com/browse/SSP-686

cc @syncrou 