### PR TITLE
Use order_service_offering instead of deprecated order_service_plan

### DIFF
--- a/app/services/catalog/submit_order.rb
+++ b/app/services/catalog/submit_order.rb
@@ -27,7 +27,7 @@ module Catalog
 
     def submit_order_item(item)
       TopologicalInventory.call do |api_instance|
-        result = api_instance.order_service_plan(item.service_plan_ref, parameters(item))
+        result = api_instance.order_service_offering(item.portfolio_item.service_offering_ref, parameters(item))
         update_item(item, result)
       end
     end

--- a/app/services/catalog/submit_order.rb
+++ b/app/services/catalog/submit_order.rb
@@ -33,9 +33,10 @@ module Catalog
     end
 
     def parameters(item)
-      TopologicalInventoryApiClient::OrderParameters.new.tap do |obj|
+      TopologicalInventoryApiClient::OrderParametersServiceOffering.new.tap do |obj|
         obj.service_parameters = item.service_parameters
         obj.provider_control_parameters = item.provider_control_parameters
+        obj.service_plan_id = item.service_plan_ref
       end
     end
 

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -30,7 +30,11 @@ describe Catalog::SubmitOrder do
 
     before do
       request_stubs = {
-        :body    => {:service_parameters => service_parameters, :provider_control_parameters => provider_control_parameters}.to_json,
+        :body    => {
+          :service_parameters => service_parameters,
+          :provider_control_parameters => provider_control_parameters,
+          :service_plan_id => service_plan_ref,
+        }.to_json,
         :headers => default_headers
       }
       stub_request(:post, "http://localhost/api/topological-inventory/v1.0/service_offerings/998/order")

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -5,54 +5,48 @@ describe Catalog::SubmitOrder do
   let(:service_parameters) { { 'var1' => 'Fred', 'var2' => 'Wilma' } }
   let(:provider_control_parameters) { { 'namespace' => 'Bedrock' } }
   let!(:order_item) do
-    create(:order_item, :portfolio_item_id           => portfolio_item.id,
-                        :service_parameters          => service_parameters,
+    create(:order_item, :service_parameters          => service_parameters,
                         :service_plan_ref            => service_plan_ref,
                         :provider_control_parameters => provider_control_parameters,
                         :order_id                    => order.id,
                         :count                       => 1,
                         :context                     => default_request)
   end
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref, :service_offering_source_ref => "17") }
-  let(:portfolio_item_id) { portfolio_item.id.to_s }
-  let(:params) { order.id.to_s }
   let(:submit_order) { described_class.new(params) }
-  let(:api_instance) { double }
-  let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }
-  let(:task) { double("task") }
-  let(:args) { an_instance_of(TopologicalInventoryApiClient::OrderParameters) }
-  let(:validater) { instance_double(Catalog::ValidateSource) }
-  let(:valid_source) { true }
 
-  before do
-    allow(ti_class).to receive(:call).and_yield(api_instance)
-    allow(Catalog::ValidateSource).to receive(:new).with(portfolio_item.service_offering_source_ref).and_return(validater)
-    allow(validater).to receive(:process).and_return(validater)
-    allow(validater).to receive(:valid).and_return(valid_source)
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost") do
+      example.call
+    end
   end
 
-  context "when the source is valid" do
-    it "fetches the array of plans" do
-      allow(task).to receive(:task_id).and_return("100")
-      allow(api_instance).to receive(:order_service_plan).with(service_plan_ref, args).and_return(task)
+  before do
+    allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+  end
 
+  context "when the order ID is valid" do
+    let(:params) { order.id.to_s }
+    let(:order_response) { TopologicalInventoryApiClient::InlineResponse200.new(:task_id => "100") }
+
+    before do
+      request_stubs = {
+        :body    => {:service_parameters => service_parameters, :provider_control_parameters => provider_control_parameters}.to_json,
+        :headers => default_headers
+      }
+      stub_request(:post, "http://localhost/api/topological-inventory/v1.0/service_offerings/998/order")
+        .with(request_stubs)
+        .to_return(:status => 200, :body => order_response.to_json, :headers => {"Content-type" => "application/json"})
+    end
+
+    it "updates the order item with the task id" do
       expect(submit_order.process.order.order_items.first.topology_task_ref).to eq("100")
     end
   end
 
-  context "when the source is not valid" do
-    let(:valid_source) { false }
-
-    it "throws unauthorized" do
-      ManageIQ::API::Common::Request.with_request(default_request) do
-        expect { submit_order.process }.to raise_error(Catalog::NotAuthorized)
-      end
-    end
-  end
-
-  context "invalid portfolio item" do
+  context "when the order ID is invalid" do
     let(:params) { 333 }
-    it "raises exception" do
+
+    it "raises an exception" do
       expect { submit_order.process }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -5,22 +5,32 @@ describe Catalog::SubmitOrder do
   let(:service_parameters) { { 'var1' => 'Fred', 'var2' => 'Wilma' } }
   let(:provider_control_parameters) { { 'namespace' => 'Bedrock' } }
   let!(:order_item) do
-    create(:order_item, :service_parameters          => service_parameters,
+    create(:order_item, :portfolio_item              => portfolio_item,
+                        :service_parameters          => service_parameters,
                         :service_plan_ref            => service_plan_ref,
                         :provider_control_parameters => provider_control_parameters,
                         :order_id                    => order.id,
                         :count                       => 1,
                         :context                     => default_request)
   end
+  let(:portfolio_item) do
+    create(:portfolio_item, :service_offering_ref => service_offering_ref, :service_offering_source_ref => "17")
+  end
   let(:submit_order) { described_class.new(params) }
+  let(:validater) { instance_double(Catalog::ValidateSource) }
+  let(:validity) { true }
 
   around do |example|
-    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost") do
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost", :SOURCES_URL => "http://localhost") do
       example.call
     end
   end
 
   before do
+    allow(Catalog::ValidateSource).to receive(:new).with(portfolio_item.service_offering_source_ref).and_return(validater)
+    allow(validater).to receive(:process).and_return(validater)
+    allow(validater).to receive(:valid).and_return(validity)
+
     allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
   end
 
@@ -28,22 +38,34 @@ describe Catalog::SubmitOrder do
     let(:params) { order.id.to_s }
     let(:order_response) { TopologicalInventoryApiClient::InlineResponse200.new(:task_id => "100") }
 
-    before do
-      request_stubs = {
-        :body    => {
-          :service_parameters => service_parameters,
-          :provider_control_parameters => provider_control_parameters,
-          :service_plan_id => service_plan_ref,
-        }.to_json,
-        :headers => default_headers
-      }
-      stub_request(:post, "http://localhost/api/topological-inventory/v1.0/service_offerings/998/order")
-        .with(request_stubs)
-        .to_return(:status => 200, :body => order_response.to_json, :headers => {"Content-type" => "application/json"})
+    context "when the source is valid" do
+      before do
+        request_stubs = {
+          :body => {
+            :service_parameters          => service_parameters,
+            :provider_control_parameters => provider_control_parameters,
+            :service_plan_id             => service_plan_ref,
+          }.to_json,
+          :headers => default_headers
+        }
+        stub_request(:post, "http://localhost/api/topological-inventory/v1.0/service_offerings/998/order")
+          .with(request_stubs)
+          .to_return(:status => 200, :body => order_response.to_json, :headers => {"Content-type" => "application/json"})
+      end
+
+      it "updates the order item with the task id" do
+        expect(submit_order.process.order.order_items.first.topology_task_ref).to eq("100")
+      end
     end
 
-    it "updates the order item with the task id" do
-      expect(submit_order.process.order.order_items.first.topology_task_ref).to eq("100")
+    context "when the source is not valid" do
+      let(:validity) { false }
+
+      it "throws an unauthorized exception" do
+        ManageIQ::API::Common::Request.with_request(default_request) do
+          expect { submit_order.process }.to raise_error(Catalog::NotAuthorized)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-466 added the `order_service_offering` api call that should be used in place of `order_service_plan`.

This is a small part of https://projects.engineering.redhat.com/browse/SSP-680, but does not directly complete the story.

The actual code change is rather small, but I adjusted the specs to use webmock so that's why there's a lot of change there. I'm sure rubocop will complain about the style, I'll fix the issues as they come in.

@syncrou @gmcculloug Please Review