### PR TITLE
Fix specs to pass in the belongs_to object

### DIFF
--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -8,7 +8,7 @@ module Catalog
 
     def process
       @order = Order.find_by!(:id => @params[:order_id])
-      order.order_items << OrderItem.create!(order_item_params)
+      order.order_items << OrderItem.create!(order_item_params.merge(:tenant => order.tenant))
       self
     end
 

--- a/spec/controllers/internal/v1x0/notify_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/notify_controller_spec.rb
@@ -6,10 +6,12 @@ describe Internal::V1x0::NotifyController, :type => :request do
   end
 
   describe "POST /notify/approval_request/:id" do
-    let(:order) { create(:order) }
-    let(:portfolio_item) { create(:portfolio_item) }
-    let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :context => default_request) }
-    let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123") }
+    let(:tenant) { create(:tenant) }
+    let(:order) { create(:order, :tenant_id => tenant.id) }
+    let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+    let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => portfolio) }
+    let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id, :context => default_request) }
+    let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123", :tenant_id => tenant.id) }
     let(:approval_transition) { instance_double("Catalog::UpdateOrderItem") }
 
     before do
@@ -26,7 +28,8 @@ describe Internal::V1x0::NotifyController, :type => :request do
   describe "POST /notify/order_item/:task_id" do
     let(:tenant) { create(:tenant) }
     let(:order) { create(:order, :tenant_id => tenant.id) }
-    let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+    let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+    let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :service_offering_ref => "123", :tenant_id => tenant.id) }
     let!(:order_item) do
       create(:order_item,
              :order_id          => order.id,

--- a/spec/models/approval_request_spec.rb
+++ b/spec/models/approval_request_spec.rb
@@ -1,11 +1,13 @@
 describe ApprovalRequest, :type => :model do
   let(:tenant) { create(:tenant) }
-  let(:order1) { create(:order) }
-  let(:order2) { create(:order) }
-  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order1.id) }
-  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order2.id) }
-  let!(:approval_request1) { create(:approval_request, :order_item_id => order_item1.id) }
-  let!(:approval_request2) { create(:approval_request, :order_item_id => order_item2.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+  let(:order1) { create(:order, :tenant_id => tenant.id) }
+  let(:order2) { create(:order, :tenant_id => tenant.id) }
+  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id, :order_id => order1.id) }
+  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id, :order_id => order2.id) }
+  let!(:approval_request1) { create(:approval_request, :order_item_id => order_item1.id, :tenant_id => tenant.id) }
+  let!(:approval_request2) { create(:approval_request, :order_item_id => order_item2.id, :tenant_id => tenant.id) }
 
   around do |example|
     ManageIQ::API::Common::Request.with_request(default_request) { example.call }

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,7 +1,9 @@
 describe OrderItem do
   let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
-  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => 123, :tenant_id => tenant.id) }
+  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item => portfolio_item, :tenant_id => tenant.id) }
 
   context "updating order item progress messages" do
     it "syncs the time between order_item and progress message" do
@@ -16,7 +18,7 @@ describe OrderItem do
 
   describe "#discard before hook" do
     context "when the order item has progress messages" do
-      let(:progress_message) { create(:progress_message, :order_item_id => order_item.id) }
+      let(:progress_message) { create(:progress_message, :order_item_id => order_item.id, :tenant_id => tenant.id) }
 
       it "destroys progress_messages associated with the order" do
         order_item.progress_messages << progress_message
@@ -29,7 +31,7 @@ describe OrderItem do
 
   describe "#undiscard before hook" do
     context "when the order item has progress messages" do
-      let(:progress_message) { create(:progress_message, :order_item_id => order_item.id) }
+      let(:progress_message) { create(:progress_message, :order_item_id => order_item.id, :tenant_id => tenant.id) }
 
       before do
         order_item.progress_messages << progress_message

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -16,7 +16,8 @@ describe Order do
   describe "#discard before hook" do
     context "when the order has order items" do
       let!(:order_item) { create(:order_item, :order_id => order1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :service_offering_ref => "123", :tenant_id => tenant.id) }
 
       it "destroys order_items associated with the order" do
         order1.order_items << order_item
@@ -30,7 +31,8 @@ describe Order do
   describe "#undiscard before hook" do
     context "when the order has order items" do
       let!(:order_item) { create(:order_item, :order_id => order1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :service_offering_ref => "123", :tenant_id => tenant.id) }
 
       before do
         order1.order_items << order_item

--- a/spec/models/progress_message_spec.rb
+++ b/spec/models/progress_message_spec.rb
@@ -1,11 +1,13 @@
 describe ProgressMessage, :type => :model do
   let(:tenant) { create(:tenant) }
-  let(:order1) { create(:order) }
-  let(:order2) { create(:order) }
-  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order1.id) }
-  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order2.id) }
-  let!(:progress_message1) { create(:progress_message, :order_item_id => order_item1.id) }
-  let!(:progress_message2) { create(:progress_message, :order_item_id => order_item2.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id) }
+  let(:order1) { create(:order, :tenant => tenant) }
+  let(:order2) { create(:order, :tenant => tenant) }
+  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item => portfolio_item, :order_id => order1.id) }
+  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item => portfolio_item, :order_id => order2.id) }
+  let!(:progress_message1) { create(:progress_message, :order_item_id => order_item1.id, :tenant => tenant) }
+  let!(:progress_message2) { create(:progress_message, :order_item_id => order_item2.id, :tenant => tenant) }
 
   around do |example|
     ManageIQ::API::Common::Request.with_request(default_request) { example.call }

--- a/spec/requests/approval_request_spec.rb
+++ b/spec/requests/approval_request_spec.rb
@@ -7,8 +7,9 @@ describe "ApprovalRequestRequests", :type => :request do
 
   let(:tenant) { create(:tenant) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id, :portfolio => portfolio) }
   let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
 
   context "v1.0" do

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -6,12 +6,13 @@ describe "OrderItemsRequests", :type => :request do
   end
 
   let(:tenant) { create(:tenant) }
+  let!(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:order_1) { create(:order, :tenant_id => tenant.id) }
   let!(:order_2) { create(:order, :tenant_id => tenant.id) }
   let!(:order_3) { create(:order, :tenant_id => tenant.id) }
   let!(:order_item_1) { create(:order_item, :order_id => order_1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
   let!(:order_item_2) { create(:order_item, :order_id => order_2.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id, :portfolio => portfolio) }
   let(:params) do
     { 'order_id'                    => order_1.id,
       'portfolio_item_id'           => portfolio_item.id,

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -139,7 +139,8 @@ describe "OrderRequests", :type => :request do
 
     context "when deleting an order where a linked order item fails" do
       let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id, :portfolio => portfolio) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
 
       before do
         order.order_items << order_item
@@ -160,7 +161,8 @@ describe "OrderRequests", :type => :request do
     context "when deleting an order where a linked order item has linked progress messages that fail" do
       let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
       let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :portfolio => portfolio, :tenant_id => tenant.id) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
 
       before do
         order.order_items << order_item
@@ -214,7 +216,8 @@ describe "OrderRequests", :type => :request do
 
     context "when restoring an order where a linked order item fails to be restored" do
       let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id, :portfolio => portfolio) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
 
       before do
         order.order_items << order_item
@@ -237,7 +240,8 @@ describe "OrderRequests", :type => :request do
     context "when restoring an order where a linked order item with a linked progress message fails to be restored" do
       let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
       let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id, :portfolio => portfolio) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
 
       before do
         order.order_items << order_item

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -2,7 +2,7 @@ describe 'Portfolio Items RBAC API' do
   let(:tenant) { create(:tenant) }
   let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:portfolio_item1) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
-  let!(:portfolio_item2) { create(:portfolio_item, :tenant_id => tenant.id) }
+  let!(:portfolio_item2) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s]) }
   let(:double_access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s, portfolio_item2.id.to_s]) }
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -20,6 +20,7 @@ describe "PortfolioItemRequests", :type => :request do
   end
   let(:portfolio_item_id)    { portfolio_item.id }
   let(:topo_ex)              { Catalog::TopologyError.new("kaboom") }
+  let(:image) { Image.create(:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.svg"))), :tenant_id => tenant.id) }
 
   describe "GET /portfolio_items/:portfolio_item_id" do
     before do
@@ -333,7 +334,8 @@ describe "PortfolioItemRequests", :type => :request do
 
     context "when copying into a different portfolio in a different tenant" do
       let(:params) { { :portfolio_id => not_my_portfolio.id } }
-      let(:not_my_portfolio) { create(:portfolio) }
+      let(:not_my_portfolio) { create(:portfolio, :tenant => other_tenant) }
+      let(:other_tenant) { create(:tenant, :external_tenant => "2") }
 
       before do
         copy_portfolio_item
@@ -360,7 +362,7 @@ describe "PortfolioItemRequests", :type => :request do
   end
 
   describe '#add_icon_to_portfolio_item' do
-    let!(:icon) { create(:icon, :tenant_id => tenant.id) }
+    let!(:icon) { create(:icon, :tenant_id => tenant.id, :portfolio_item => portfolio_item, :image => image) }
 
     context "when adding an icon to a portfolio_item" do
       before do

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -7,7 +7,7 @@ describe 'Portfolios API' do
 
   let(:tenant)           { create(:tenant) }
   let!(:portfolio)       { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio_item)  { create(:portfolio_item, :tenant_id => tenant.id) }
+  let!(:portfolio_item)  { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => portfolio) }
   let!(:portfolio_items) { portfolio.portfolio_items << portfolio_item }
   let(:portfolio_id)     { portfolio.id }
 
@@ -198,7 +198,7 @@ describe 'Portfolios API' do
     end
 
     context "when restoring a portfolio with portfolio_items that were discarded previously" do
-      let!(:second_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :discarded_at => 1.minute.ago, :tenant_id => tenant.id) }
+      let!(:second_item) { create(:portfolio_item, :portfolio => portfolio, :discarded_at => 1.minute.ago, :tenant_id => tenant.id) }
 
       before do
         portfolio.discard

--- a/spec/requests/progress_message_spec.rb
+++ b/spec/requests/progress_message_spec.rb
@@ -8,7 +8,8 @@ describe "ProgressMessageRequests", :type => :request do
   let(:tenant) { create(:tenant) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
   let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id, :portfolio => portfolio) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
   let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
 
   context "v1.0" do

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -1,9 +1,16 @@
 describe Catalog::AddToOrder do
   let(:service_offering_ref) { "998" }
-  let(:order) { create(:order) }
+  let(:tenant) { create(:tenant) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
   let(:order_id) { order.id.to_s }
-  let(:order_item) { create(:order_item, :portfolio_item_id => portfolio_item.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref, :owner => 'wilma') }
+  let(:order_item) { create(:order_item, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
+  let(:portfolio_item) do
+    create(:portfolio_item, :service_offering_ref => service_offering_ref,
+                            :portfolio            => portfolio,
+                            :tenant_id            => tenant.id,
+                            :owner                => 'wilma')
+  end
   let(:portfolio_item_id) { portfolio_item.id.to_s }
 
   let(:params) do

--- a/spec/services/catalog/approval_transition_spec.rb
+++ b/spec/services/catalog/approval_transition_spec.rb
@@ -5,20 +5,25 @@ describe Catalog::ApprovalTransition do
 
   let(:req) { { :headers => default_headers, :original_url => "localhost/nope" } }
 
-  let(:order) { create(:order) }
+  let(:tenant) { create(:tenant) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id) }
 
   let!(:order_item) do
     ManageIQ::API::Common::Request.with_request(req) do
       create(:order_item,
              :order_id          => order.id,
-             :portfolio_item_id => "1")
+             :tenant_id         => tenant.id,
+             :portfolio_item_id => portfolio_item.id)
     end
   end
 
   let(:approval) do
     create(:approval_request,
            :workflow_ref  => "1",
-           :order_item_id => order_item.id)
+           :order_item_id => order_item.id,
+           :tenant_id     => tenant.id)
   end
 
   let(:order_item_transition) { described_class.new(order_item.id) }

--- a/spec/services/catalog/cancel_order_spec.rb
+++ b/spec/services/catalog/cancel_order_spec.rb
@@ -1,8 +1,10 @@
 describe Catalog::CancelOrder do
-  let(:order) { create(:order) }
-  let(:portfolio_item) { create(:portfolio_item) }
-  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
-  let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id) }
+  let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
+  let(:order_item) { create(:order_item, :tenant_id => tenant.id, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+  let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :tenant_id => tenant.id) }
   let(:subject) { described_class.new(order.id) }
 
   describe "#process" do

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -69,7 +69,7 @@ describe Catalog::CreateApprovalRequest do
 
     context "#create_approval_request" do
       let(:request_out) { ApprovalApiClient::RequestOut.new(:workflow_id => "1", :id => 2) }
-      let(:approval_request) { create_approval_request.send(:create_approval_request, request_out) }
+      let(:approval_request) { create_approval_request.send(:create_approval_request, request_out, order_item) }
 
       it "returns an ApprovalRequest Object" do
         expect(approval_request.class.name).to eq "ApprovalRequest"

--- a/spec/services/catalog/notify_approval_request_spec.rb
+++ b/spec/services/catalog/notify_approval_request_spec.rb
@@ -3,10 +3,12 @@ describe Catalog::NotifyApprovalRequest do
 
   describe "#process" do
     context "when the class is an approval request" do
-      let(:order) { create(:order) }
-      let(:portfolio_item) { create(:portfolio_item) }
-      let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
-      let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123") }
+      let(:tenant) { create(:tenant) }
+      let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+      let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+      let(:order) { create(:order, :tenant_id => tenant.id) }
+      let(:order_item) { create(:order_item, :order_id => order.id, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id) }
+      let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123", :tenant_id => tenant.id) }
       let(:ref_id) { "123" }
       let(:approval_transition) { instance_double("Catalog::ApprovalTransition") }
 

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -10,10 +10,15 @@ describe Catalog::OrderItemSanitizedParameters do
       Catalog::OrderItemSanitizedParameters.new(params)
     end
   end
+  let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
 
   let(:order_item) do
-    create(:order_item, :portfolio_item_id           => 100,
-                        :order_id                    => 45,
+    create(:order_item, :portfolio_item_id           => portfolio_item.id,
+                        :order_id                    => order.id,
+                        :tenant_id                   => tenant.id,
                         :service_plan_ref            => service_plan_ref,
                         :service_parameters          => service_parameters,
                         :provider_control_parameters => { 'a' => 1 },

--- a/spec/services/catalog/order_state_transition_spec.rb
+++ b/spec/services/catalog/order_state_transition_spec.rb
@@ -1,9 +1,11 @@
 describe Catalog::OrderStateTransition do
   let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
   let(:order) { create(:order, :tenant_id => tenant.id) }
 
-  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
-  let(:order_item2) { create(:order_item, :order_id => order.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
+  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
+  let(:order_item2) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
 
   describe "#process" do
     before do

--- a/spec/services/catalog/override_icon_spec.rb
+++ b/spec/services/catalog/override_icon_spec.rb
@@ -1,8 +1,10 @@
 describe Catalog::OverrideIcon do
   let(:tenant) { create(:tenant) }
-  let!(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
-  let!(:icon1) { create(:icon, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id) }
-  let!(:icon2) { create(:icon, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id) }
+  let(:image) { Image.create(:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.svg"))), :tenant_id => tenant.id) }
+  let!(:icon1) { create(:icon, :image => image, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id) }
+  let!(:icon2) { create(:icon, :image => image, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id) }
 
   describe "#process" do
     context "when overriding an icon" do

--- a/spec/services/catalog/provider_control_parameters_spec.rb
+++ b/spec/services/catalog/provider_control_parameters_spec.rb
@@ -6,7 +6,9 @@ describe Catalog::ProviderControlParameters do
   let(:source_id) { "1" }
   let(:params) { portfolio_item.id }
   let(:provider_control_parameters) { described_class.new(params) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_source_ref => source_id) }
+  let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => portfolio, :service_offering_source_ref => source_id) }
   let(:project1_name) { 'project-one' }
   let(:project2_name) { 'project-two' }
   let(:project1) do

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -1,6 +1,8 @@
 describe Catalog::ServicePlans do
   let(:service_offering_ref) { "998" }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+  let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => portfolio, :service_offering_ref => service_offering_ref) }
   let(:params) { portfolio_item.id }
   let(:service_plans) { described_class.new(params) }
   let(:api_instance) { double }

--- a/spec/services/catalog/soft_delete_restore_spec.rb
+++ b/spec/services/catalog/soft_delete_restore_spec.rb
@@ -1,6 +1,7 @@
 describe Catalog::SoftDeleteRestore do
   let(:tenant) { create(:tenant) }
-  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :discarded_at => Time.current) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id, :discarded_at => Time.current) }
 
   describe "#process" do
     context "when restoring a soft-deleted record" do

--- a/spec/services/catalog/soft_delete_spec.rb
+++ b/spec/services/catalog/soft_delete_spec.rb
@@ -1,6 +1,7 @@
 describe Catalog::SoftDelete do
   let(:tenant) { create(:tenant) }
-  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
 
   describe "#process" do
     context "when soft-deleting a record" do

--- a/spec/services/catalog/submit_order_spec.rb
+++ b/spec/services/catalog/submit_order_spec.rb
@@ -1,7 +1,10 @@
 describe Catalog::SubmitOrder do
+  let(:tenant) { create(:tenant) }
+  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
   let(:service_offering_ref) { "998" }
   let(:service_plan_ref) { "991" }
-  let(:order) { create(:order) }
+  let(:order) { create(:order, :tenant_id => tenant.id) }
   let(:service_parameters) { { 'var1' => 'Fred', 'var2' => 'Wilma' } }
   let(:provider_control_parameters) { { 'namespace' => 'Bedrock' } }
   let!(:order_item) do
@@ -10,10 +13,11 @@ describe Catalog::SubmitOrder do
                         :service_plan_ref            => service_plan_ref,
                         :provider_control_parameters => provider_control_parameters,
                         :order_id                    => order.id,
+                        :tenant_id                   => tenant.id,
                         :count                       => 1,
                         :context                     => default_request)
   end
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref, :portfolio => portfolio, :tenant_id => tenant.id) }
   let(:portfolio_item_id) { portfolio_item.id.to_s }
   let(:params) { order.id.to_s }
   let(:submit_order) { described_class.new(params) }

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -5,15 +5,20 @@ describe Catalog::UpdateOrderItem do
     let(:client) { double(:client) }
     let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client, nil) }
     let(:payload) { {"task_id" => "123", "status" => status, "state" => state, "context" => "payloadcontext"} }
+    let(:tenant) { create(:tenant) }
+    let(:order) { create(:order, :tenant_id => tenant.id) }
+    let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+    let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio, :tenant_id => tenant.id) }
     let!(:item) do
       ManageIQ::API::Common::Request.with_request(default_request) do
         create(:order_item,
                :order_id          => order.id,
                :topology_task_ref => topology_task_ref,
-               :portfolio_item_id => "1")
+               :tenant_id         => tenant.id,
+               :portfolio_item_id => portfolio_item.id)
       end
     end
-    let(:order) { create(:order) }
+    let(:order) { create(:order, :tenant_id => tenant.id) }
     let(:subject) { described_class.new(topic) }
     let(:api_instance) { instance_double("TopologicalInventoryApiClient::DefaultApi") }
     let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }


### PR DESCRIPTION
We need to pass in the tenant, portfolio, portfolio_item and other belongs_to objects when building our spec objects.

https://projects.engineering.redhat.com/browse/SSP-730