### PR TITLE
Refactor factories to use associations and tenants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-gem 'acts_as_tenant'
 gem 'dhasher'
 gem 'discard', :git => 'https://github.com/jhawthorn/discard', :branch => 'master'
 gem 'jbuilder', '~> 2.0'

--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -37,7 +37,7 @@ module Api
       private
 
       def icon_params
-        params.require(:content)
+        params.require([:content, :portfolio_item_id])
         icon_patch_params
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::API
   end
 
   def current_tenant(current_user)
-    Tenant.find_or_create_by(:external_tenant => current_user.tenant)
+    Tenant.find_or_create_by(:external_tenant => current_user.tenant.to_i)
   end
 
   def check_entitled(entitlement)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+require "acts_as_tenant"
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -6,7 +6,7 @@ class PortfolioItem < ApplicationRecord
   default_scope -> { kept }
 
   has_many :icons, :dependent => :destroy
-  belongs_to :portfolio
+  belongs_to :portfolio, :optional => true
   validates :service_offering_ref, :presence => true
 
   def resolved_workflow_refs

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,6 +1,7 @@
 class Tenant < ApplicationRecord
   validates :external_tenant, :uniqueness => true, :presence => true
 
+  before_validation :setup_settings, :unless => proc { settings.nil? }
   after_initialize :setup_settings, :unless => proc { settings.nil? }
 
   def add_setting(name, value)

--- a/app/services/catalog/create_approval_request.rb
+++ b/app/services/catalog/create_approval_request.rb
@@ -23,7 +23,7 @@ module Catalog
     def submit_approval_requests(order_item)
       workflows(order_item.portfolio_item).each do |workflow|
         response = Approval.call { |api| api.create_request(workflow, request_body_from(order_item)) }
-        order_item.approval_requests << create_approval_request(response)
+        order_item.approval_requests << create_approval_request(response, order_item)
 
         order_item.update_message("info", "Approval Request Submitted for workflow #{workflow}, ID: #{order_item.approval_requests.last.id}")
       end
@@ -47,11 +47,12 @@ module Catalog
       portfolio_item.resolved_workflow_refs
     end
 
-    def create_approval_request(req)
+    def create_approval_request(req, order_item)
       ApprovalRequest.new.tap do |approval|
         approval.workflow_ref         = req.workflow_id
         approval.approval_request_ref = req.id
         approval.state                = req.decision.to_sym
+        approval.order_item           = order_item
         approval.save!
       end
     end

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -53,9 +53,10 @@ module ServiceOffering
       return if service_offering_icon.data.nil?
 
       svc = Catalog::CreateIcon.new(
-        :content    => Base64.strict_encode64(service_offering_icon.data),
-        :source_ref => service_offering_icon.source_ref,
-        :source_id  => service_offering_icon.source_id
+        :content        => Base64.strict_encode64(service_offering_icon.data),
+        :source_ref     => service_offering_icon.source_ref,
+        :source_id      => service_offering_icon.source_id,
+        :portfolio_item => @item
       )
 
       svc.process.icon

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,1 +1,0 @@
-require "acts_as_tenant"

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,0 +1,1 @@
+require "acts_as_tenant"

--- a/spec/controllers/api/v1x0/application_controller_spec.rb
+++ b/spec/controllers/api/v1x0/application_controller_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe ApplicationController, :type => :request do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio)         { Portfolio.create!(:name => 'tenant_portfolio', :description => 'tenant desc', :tenant_id => tenant.id, :owner => 'wilma') }
-  let(:portfolio_id)      { portfolio.id }
+  let(:portfolio) { create(:portfolio, :name => 'tenant_portfolio', :description => 'tenant desc', :owner => 'wilma') }
+  let(:portfolio_id) { portfolio.id }
 
   context "with api version v1" do
     around do |example|

--- a/spec/controllers/internal/v1x0/notify_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/notify_controller_spec.rb
@@ -6,10 +6,7 @@ describe Internal::V1x0::NotifyController, :type => :request do
   end
 
   describe "POST /notify/approval_request/:id" do
-    let(:order) { create(:order) }
-    let(:portfolio_item) { create(:portfolio_item) }
-    let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :context => default_request) }
-    let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id, :approval_request_ref => "123") }
+    let!(:approval_request) { create(:approval_request, :approval_request_ref => "123") }
     let(:approval_transition) { instance_double("Catalog::UpdateOrderItem") }
 
     before do
@@ -24,15 +21,8 @@ describe Internal::V1x0::NotifyController, :type => :request do
   end
 
   describe "POST /notify/order_item/:task_id" do
-    let(:tenant) { create(:tenant) }
-    let(:order) { create(:order, :tenant_id => tenant.id) }
-    let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
     let!(:order_item) do
-      create(:order_item,
-             :order_id          => order.id,
-             :portfolio_item_id => portfolio_item.id,
-             :tenant_id         => tenant.id,
-             :topology_task_ref => "321")
+      create(:order_item, :topology_task_ref => "321")
     end
     let(:update_order_item) { instance_double("Catalog::UpdateOrderItem") }
 

--- a/spec/factories/approval_requests.rb
+++ b/spec/factories/approval_requests.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
-  factory :approval_request do
+  factory :approval_request, :traits => [:has_tenant] do
     approval_request_ref { "MyString" }
     workflow_ref { "MyString" }
     state { :undecided }
-    order_item_id { "" }
+
+    order_item
   end
 end

--- a/spec/factories/icon.rb
+++ b/spec/factories/icon.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
-  factory :icon do
+  factory :icon, :traits => [:has_tenant] do
     sequence(:source_ref) { |n| "source_ref_#{n}" }
     sequence(:source_id)  { |n| "source_id_#{n}" }
-    sequence(:image_id)
+
+    image
+    portfolio_item
   end
 end

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :image, :traits => [:has_tenant] do
+    content { Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.svg"))) }
+    extension { "SVG" }
+  end
+end

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -1,5 +1,3 @@
 FactoryBot.define do
-  factory :order do
-    owner { default_username }
-  end
+  factory :order, :traits => [:has_owner, :has_tenant]
 end

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -1,10 +1,12 @@
 FactoryBot.define do
-  factory :order_item do
+  factory :order_item, :traits => [:has_owner, :has_tenant] do
     service_parameters { {'name' => 'fred'} }
     provider_control_parameters { {'namespace' => 'barney'} }
     service_plan_ref { "something" }
     count { 1 }
-    owner { default_username }
     insights_request_id { "insights-request-id" }
+
+    order
+    portfolio_item
   end
 end

--- a/spec/factories/portfolio_items.rb
+++ b/spec/factories/portfolio_items.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
-  factory :portfolio_item do
+  factory :portfolio_item, :traits => [:has_owner, :has_tenant] do
     sequence(:name)                 { |n| "PortfolioItem_name_#{n}" }
     sequence(:display_name)         { |n| "PortfolioItem_display_name_#{n}" }
     sequence(:description)          { |n| "PortfolioItem_description_#{n}" }
     sequence(:service_offering_ref) { |n| (111 + n).to_s }
     sequence(:service_offering_source_ref) { |n| (222 + n).to_s }
-    owner { default_username }
+
+    portfolio
   end
 end

--- a/spec/factories/portfolios.rb
+++ b/spec/factories/portfolios.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
-  factory :portfolio do
+  factory :portfolio, :traits => [:has_owner, :has_tenant] do
     sequence(:name)         { |n| "Portfolio_name_#{n}" }
     sequence(:description)  { |n| "Portfolio_description_#{n}" }
     sequence(:image_url)    { |n| "https://portfolio#{n}.com/image/#{n}" }
     enabled                 { "true" }
-    owner                   { default_username }
   end
 end

--- a/spec/factories/progress_messages.rb
+++ b/spec/factories/progress_messages.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :progress_message do
+  factory :progress_message, :traits => [:has_tenant] do
     sequence(:message) { |n| "Message_#{n}" }
   end
 end

--- a/spec/factories/shared_traits.rb
+++ b/spec/factories/shared_traits.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  trait :has_tenant do
+    tenant { Tenant.first_or_create!(:external_tenant => default_account_number) }
+  end
+
+  trait :has_owner do
+    owner { default_username }
+  end
+end

--- a/spec/factories/tenants.rb
+++ b/spec/factories/tenants.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :tenant do
     external_tenant { default_account_number }
+    settings do
+      {
+        :icon             => "<svg rel='stylesheet'>image</svg>",
+        :default_workflow => "1"
+      }
+    end
   end
 end

--- a/spec/lib/open_api/serializer_spec.rb
+++ b/spec/lib/open_api/serializer_spec.rb
@@ -1,6 +1,5 @@
 describe OpenApi::Serializer do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :portfolio => create(:portfolio, :tenant_id => tenant.id)) }
+  let(:portfolio_item) { create(:portfolio_item) }
   let(:request_path)   { "/api/v1.0/portfolio_items" }
 
 

--- a/spec/lib/rbac/roles_spec.rb
+++ b/spec/lib/rbac/roles_spec.rb
@@ -1,5 +1,4 @@
 describe RBAC::Roles do
-  let(:opts) { {:name => 'Catalog Administrator', :scope => 'principal'} }
   let(:response_headers) { {"Content-Type" => 'application/json'} }
   let(:catalog_admin) do
     { :data => data, :meta => { :count => count } }

--- a/spec/models/approval_request_spec.rb
+++ b/spec/models/approval_request_spec.rb
@@ -1,11 +1,10 @@
 describe ApprovalRequest, :type => :model do
-  let(:tenant) { create(:tenant) }
-  let(:order1) { create(:order) }
   let(:order2) { create(:order) }
-  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order1.id) }
-  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order2.id) }
-  let!(:approval_request1) { create(:approval_request, :order_item_id => order_item1.id) }
-  let!(:approval_request2) { create(:approval_request, :order_item_id => order_item2.id) }
+  let(:portfolio_item) { create(:portfolio_item) }
+  let(:order_item1) { create(:order_item, :portfolio_item => portfolio_item) }
+  let(:order_item2) { create(:order_item, :portfolio_item => portfolio_item, :order => order2) }
+  let!(:approval_request1) { create(:approval_request, :order_item => order_item1) }
+  let!(:approval_request2) { create(:approval_request, :order_item => order_item2) }
 
   around do |example|
     ManageIQ::API::Common::Request.with_request(default_request) { example.call }

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -8,7 +8,7 @@ describe OrderItem do
       last_message = order_item.progress_messages.last
       expect(order_item.updated_at).to be_a(Time)
       expect(last_message.order_item_id.to_i).to eq order_item.id
-      expect(last_message.tenant_id).to eq(tenant.id)
+      expect(last_message.tenant_id).to eq(order_item.tenant.id)
     end
   end
 

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,7 +1,5 @@
 describe OrderItem do
-  let(:tenant) { create(:tenant) }
-  let(:order) { create(:order, :tenant_id => tenant.id) }
-  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => 123, :tenant_id => tenant.id) }
+  let(:order_item) { create(:order_item) }
 
   context "updating order item progress messages" do
     it "syncs the time between order_item and progress message" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,8 +1,7 @@
 describe Order do
-  let(:tenant) { create(:tenant) }
-  let!(:order1) { create(:order, :tenant_id => tenant.id) }
-  let!(:order2) { create(:order, :tenant_id => tenant.id) }
-  let!(:order3) { create(:order, :tenant_id => tenant.id, :owner => 'barney') }
+  let!(:order1) { create(:order) }
+  let!(:order2) { create(:order) }
+  let!(:order3) { create(:order, :owner => 'barney') }
 
   context "scoped by owner" do
     it "#by_owner" do
@@ -15,8 +14,7 @@ describe Order do
 
   describe "#discard before hook" do
     context "when the order has order items" do
-      let!(:order_item) { create(:order_item, :order_id => order1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let!(:order_item) { create(:order_item, :order_id => order1.id) }
 
       it "destroys order_items associated with the order" do
         order1.order_items << order_item
@@ -29,8 +27,7 @@ describe Order do
 
   describe "#undiscard before hook" do
     context "when the order has order items" do
-      let!(:order_item) { create(:order_item, :order_id => order1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let!(:order_item) { create(:order_item, :order_id => order1.id) }
 
       before do
         order1.order_items << order_item

--- a/spec/models/portfolio_item_spec.rb
+++ b/spec/models/portfolio_item_spec.rb
@@ -1,6 +1,5 @@
 describe PortfolioItem do
-  let(:tenant) { create(:tenant) }
-  let(:item) { PortfolioItem.new(:tenant_id => tenant.id) }
+  let(:item) { build(:portfolio_item) }
 
   let(:service_offering_ref) { "1" }
   let(:owner) { 'wilma' }
@@ -11,6 +10,7 @@ describe PortfolioItem do
     end
 
     it "is not valid without a service_offering_ref" do
+      item.service_offering_ref = nil
       expect(item).to_not be_valid
     end
 
@@ -26,6 +26,7 @@ describe PortfolioItem do
     end
 
     it "is not valid without an owner" do
+      item.owner = nil
       expect(item).to_not be_valid
     end
 
@@ -38,14 +39,13 @@ describe PortfolioItem do
   context "#item_workflow_ref" do
     let(:item_workflow_ref) { "portfolio_item_workflow_ref" }
     let(:portfolio_workflow_ref) { "portfolio_workflow_ref" }
-    let(:portfolio) { create(:portfolio, :workflow_ref => portfolio_workflow_ref, :tenant_id => tenant.id) }
+    let(:portfolio) { create(:portfolio, :workflow_ref => portfolio_workflow_ref) }
 
     let(:portfolio_item) do
       create(:portfolio_item,
              :service_offering_ref => "123",
              :portfolio_id         => portfolio.id,
-             :workflow_ref         => item_workflow_ref,
-             :tenant_id            => tenant.id)
+             :workflow_ref         => item_workflow_ref)
     end
 
     let(:ref) { portfolio_item.send(:item_workflow_ref) }

--- a/spec/models/progress_message_spec.rb
+++ b/spec/models/progress_message_spec.rb
@@ -1,9 +1,8 @@
 describe ProgressMessage, :type => :model do
-  let(:tenant) { create(:tenant) }
   let(:order1) { create(:order) }
   let(:order2) { create(:order) }
-  let(:order_item1) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order1.id) }
-  let(:order_item2) { create(:order_item, :tenant_id => tenant.id, :portfolio_item_id => 1, :order_id => order2.id) }
+  let(:order_item1) { create(:order_item, :order => order1) }
+  let(:order_item2) { create(:order_item, :order => order2) }
   let!(:progress_message1) { create(:progress_message, :order_item_id => order_item1.id) }
   let!(:progress_message2) { create(:progress_message, :order_item_id => order_item2.id) }
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,11 +1,5 @@
 describe Tenant, :type => :model do
-  let(:tenant) do
-    create(:tenant,
-           :settings => {
-             :icon             => "<svg rel='stylesheet'>image</svg>",
-             :default_workflow => "1"
-           })
-  end
+  let!(:tenant) { create(:tenant) }
   let(:retreived_tenant) { Tenant.find(tenant.id) }
 
   describe "#setup_settings" do

--- a/spec/requests/approval_request_spec.rb
+++ b/spec/requests/approval_request_spec.rb
@@ -5,15 +5,11 @@ describe "ApprovalRequestRequests", :type => :request do
     end
   end
 
-  let(:tenant) { create(:tenant) }
-  let(:order) { create(:order, :tenant_id => tenant.id) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
-  let!(:approval_request) { create(:approval_request, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
+  let!(:approval_request) { create(:approval_request) }
 
   context "v1.0" do
     it "lists progress messages" do
-      get "/#{api}/order_items/#{order_item.id}/approval_requests", :headers => default_headers
+      get "/#{api}/order_items/#{approval_request.order_item.id}/approval_requests", :headers => default_headers
 
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
@@ -21,10 +17,8 @@ describe "ApprovalRequestRequests", :type => :request do
     end
 
     context "when the order item does not exist" do
-      let(:order_item_id) { 0 }
-
       it "returns a 404" do
-        get "/#{api}/order_items/#{order_item_id}/approval_requests", :headers => default_headers
+        get "/#{api}/order_items/0/approval_requests", :headers => default_headers
 
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe("v1.0 - GraphQL") do
     end
   end
 
-  let(:tenant) { create(:tenant) }
-  let!(:portfolio_a) { create(:portfolio, :tenant_id => tenant.id, :description => 'test a desc', :name => "test_a", :owner => "234") }
-  let!(:portfolio_b) { create(:portfolio, :tenant_id => tenant.id, :description => 'test b desc', :name => "test_b", :owner => "123") }
+  let!(:portfolio_a) { create(:portfolio, :description => 'test a desc', :name => "test_a", :owner => "234") }
+  let!(:portfolio_b) { create(:portfolio, :description => 'test b desc', :name => "test_b", :owner => "123") }
 
   let(:graphql_portfolio_query) { { "query" => "{ portfolios { id name } }" } }
 

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -31,15 +31,13 @@ describe "IconsRequests", :type => :request do
   describe "#create" do
     let!(:ocp_jpg_image) do
       create(:image,
-             :content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.jpg"))),
-             :extension => "JPEG"
-            )
+             :content   => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.jpg"))),
+             :extension => "JPEG")
     end
     let!(:ocp_png_image) do
       create(:image,
-             :content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.png"))),
-             :extension => "PNG"
-            )
+             :content   => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.png"))),
+             :extension => "PNG")
     end
 
     before { post "#{api}/icons", :params => params, :headers => default_headers }
@@ -68,9 +66,9 @@ describe "IconsRequests", :type => :request do
     context "when uploading a duplicate png icon" do
       let(:params) do
         {
-          :content    => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.png"))),
-          :source_id  => "29",
-          :source_ref => "icon_ref",
+          :content           => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.png"))),
+          :source_id         => "29",
+          :source_ref        => "icon_ref",
           :portfolio_item_id => portfolio_item.id
         }
       end
@@ -83,9 +81,9 @@ describe "IconsRequests", :type => :request do
     context "when uploading a duplicate jpg icon" do
       let(:params) do
         {
-          :content    => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.jpg"))),
-          :source_id  => "29",
-          :source_ref => "icon_ref",
+          :content           => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.jpg"))),
+          :source_id         => "29",
+          :source_ref        => "icon_ref",
           :portfolio_item_id => portfolio_item.id
         }
       end

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -5,16 +5,14 @@ describe "OrderItemsRequests", :type => :request do
     end
   end
 
-  let(:tenant) { create(:tenant) }
-  let!(:order_1) { create(:order, :tenant_id => tenant.id) }
-  let!(:order_2) { create(:order, :tenant_id => tenant.id) }
-  let!(:order_3) { create(:order, :tenant_id => tenant.id) }
-  let!(:order_item_1) { create(:order_item, :order_id => order_1.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let!(:order_item_2) { create(:order_item, :order_id => order_2.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+  let!(:order_1) { create(:order) }
+  let!(:order_2) { create(:order) }
+  let!(:order_3) { create(:order) }
+  let!(:order_item_1) { create(:order_item, :order => order_1) }
+  let!(:order_item_2) { create(:order_item, :order => order_2) }
   let(:params) do
     { 'order_id'                    => order_1.id,
-      'portfolio_item_id'           => portfolio_item.id,
+      'portfolio_item_id'           => order_item_1.portfolio_item.id,
       'count'                       => 1,
       'service_parameters'          => {'name' => 'fred'},
       'provider_control_parameters' => {'age' => 50},

--- a/spec/requests/orders_rbac_spec.rb
+++ b/spec/requests/orders_rbac_spec.rb
@@ -1,8 +1,7 @@
 describe "OrderRequests", :type => :request do
-  let(:tenant) { create(:tenant) }
-  let!(:order1) { create(:order, :tenant_id => tenant.id) }
-  let!(:order2) { create(:order, :tenant_id => tenant.id) }
-  let!(:order3) { create(:order, :tenant_id => tenant.id, :owner => 'barney') }
+  let!(:order1) { create(:order) }
+  let!(:order2) { create(:order) }
+  let!(:order3) { create(:order, :owner => 'barney') }
   let(:user_access_obj) { instance_double(RBAC::Access, :owner_scoped? => true, :accessible? => true) }
   let(:admin_access_obj) { instance_double(RBAC::Access, :owner_scoped? => false, :accessible? => true, :id_list => []) }
 

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -4,9 +4,9 @@ describe "OrderRequests", :type => :request do
       example.call
     end
   end
-  let(:tenant) { create(:tenant) }
-  let!(:order) { create(:order, :tenant_id => tenant.id) }
-  let!(:order2) { create(:order, :tenant_id => tenant.id) }
+
+  let!(:order) { create(:order) }
+  let!(:order2) { create(:order) }
 
   # TODO: Update this context with new logic. Will be fixed with
   # https://projects.engineering.redhat.com/browse/SSP-237

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -138,8 +138,8 @@ describe "OrderRequests", :type => :request do
     end
 
     context "when deleting an order where a linked order item fails" do
-      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
 
       before do
         order.order_items << order_item
@@ -158,9 +158,9 @@ describe "OrderRequests", :type => :request do
     end
 
     context "when deleting an order where a linked order item has linked progress messages that fail" do
-      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+      let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
 
       before do
         order.order_items << order_item
@@ -213,8 +213,8 @@ describe "OrderRequests", :type => :request do
     end
 
     context "when restoring an order where a linked order item fails to be restored" do
-      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
 
       before do
         order.order_items << order_item
@@ -235,9 +235,9 @@ describe "OrderRequests", :type => :request do
     end
 
     context "when restoring an order where a linked order item with a linked progress message fails to be restored" do
-      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-      let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id, :tenant_id => tenant.id) }
-      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
+      let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+      let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id) }
+      let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
 
       before do
         order.order_items << order_item

--- a/spec/requests/portfolio_items_rbac_spec.rb
+++ b/spec/requests/portfolio_items_rbac_spec.rb
@@ -1,8 +1,7 @@
 describe 'Portfolio Items RBAC API' do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio_item1) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
-  let!(:portfolio_item2) { create(:portfolio_item, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio) }
+  let!(:portfolio_item1) { create(:portfolio_item, :portfolio => portfolio) }
+  let!(:portfolio_item2) { create(:portfolio_item) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s]) }
   let(:double_access_obj) { instance_double(RBAC::Access, :accessible? => true, :owner_scoped? => true, :id_list => [portfolio_item1.id.to_s, portfolio_item2.id.to_s]) }
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -333,7 +333,7 @@ describe "PortfolioItemRequests", :type => :request do
 
     context "when copying into a different portfolio in a different tenant" do
       let(:params) { { :portfolio_id => not_my_portfolio.id } }
-      let(:not_my_portfolio) { create(:portfolio) }
+      let(:not_my_portfolio) { create(:portfolio, :tenant => create(:tenant, :external_tenant => "xyz")) }
 
       before do
         copy_portfolio_item

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -7,16 +7,14 @@ describe "PortfolioItemRequests", :type => :request do
 
   let(:service_offering_ref) { "998" }
   let(:service_offering_source_ref) { "568" }
-  let(:tenant) { create(:tenant) }
-  let(:order) { create(:order, :tenant_id => tenant.id) }
-  let!(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+  let(:order) { create(:order) }
+  let!(:portfolio) { create(:portfolio) }
   let!(:portfolio_items) { portfolio.portfolio_items << portfolio_item }
   let(:portfolio_id) { portfolio.id }
   let(:portfolio_item) do
     create(:portfolio_item, :service_offering_ref        => service_offering_ref,
                             :service_offering_source_ref => service_offering_source_ref,
-                            :portfolio_id                => portfolio.id,
-                            :tenant_id                   => tenant.id)
+                            :portfolio_id                => portfolio.id)
   end
   let(:portfolio_item_id)    { portfolio_item.id }
   let(:topo_ex)              { Catalog::TopologyError.new("kaboom") }
@@ -313,7 +311,7 @@ describe "PortfolioItemRequests", :type => :request do
 
     context "when copying into a different portfolio" do
       let(:params) { { :portfolio_id => new_portfolio.id } }
-      let(:new_portfolio) { create(:portfolio, :tenant_id => tenant.id) }
+      let(:new_portfolio) { create(:portfolio) }
 
       before do
         copy_portfolio_item
@@ -360,7 +358,7 @@ describe "PortfolioItemRequests", :type => :request do
   end
 
   describe '#add_icon_to_portfolio_item' do
-    let!(:icon) { create(:icon, :tenant_id => tenant.id) }
+    let!(:icon) { create(:icon) }
 
     context "when adding an icon to a portfolio_item" do
       before do

--- a/spec/requests/portfolios_rbac_read_access_spec.rb
+++ b/spec/requests/portfolios_rbac_read_access_spec.rb
@@ -1,7 +1,6 @@
 describe 'Portfolios Read Access RBAC API' do
-  let(:tenant) { create(:tenant) }
-  let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio1) { create(:portfolio) }
+  let!(:portfolio2) { create(:portfolio) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :id_list => id_list) }
   let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
   let(:id_list) { [] }

--- a/spec/requests/portfolios_rbac_spec.rb
+++ b/spec/requests/portfolios_rbac_spec.rb
@@ -1,7 +1,6 @@
 describe 'Portfolios RBAC API' do
-  let(:tenant) { create(:tenant) }
-  let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio1) { create(:portfolio) }
+  let!(:portfolio2) { create(:portfolio) }
   let(:access_obj) { instance_double(RBAC::Access, :owner_scoped? => false, :accessible? => true, :id_list => [portfolio1.id.to_s]) }
   let(:double_access_obj) { instance_double(RBAC::Access, :owner_scoped? => false, :accessible? => true, :id_list => [portfolio1.id.to_s, portfolio2.id.to_s]) }
 

--- a/spec/requests/portfolios_rbac_write_access_spec.rb
+++ b/spec/requests/portfolios_rbac_write_access_spec.rb
@@ -1,7 +1,6 @@
 describe 'Portfolios Write Access RBAC API' do
-  let(:tenant) { create(:tenant) }
-  let!(:portfolio1) { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
+  let!(:portfolio1) { create(:portfolio) }
+  let!(:portfolio2) { create(:portfolio) }
   let(:access_obj) { instance_double(RBAC::Access, :accessible? => true, :id_list => id_list) }
   let(:valid_attributes) { {:name => 'Fred', :description => "Fred's Portfolio" } }
   let(:updated_attributes) { {:name => 'Barney', :description => "Barney's Portfolio" } }

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -5,9 +5,8 @@ describe 'Portfolios API' do
     end
   end
 
-  let(:tenant)           { create(:tenant) }
-  let!(:portfolio)       { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio_item)  { create(:portfolio_item, :tenant_id => tenant.id) }
+  let!(:portfolio)       { create(:portfolio) }
+  let!(:portfolio_item)  { create(:portfolio_item, :portfolio => portfolio) }
   let!(:portfolio_items) { portfolio.portfolio_items << portfolio_item }
   let(:portfolio_id)     { portfolio.id }
 
@@ -72,8 +71,8 @@ describe 'Portfolios API' do
     end
 
     context "with filter" do
-      let!(:portfolio_filter1) { create(:portfolio, :tenant_id => tenant.id, :name => "testfilter1") }
-      let!(:portfolio_filter2) { create(:portfolio, :tenant_id => tenant.id, :name => "testfilter2") }
+      let!(:portfolio_filter1) { create(:portfolio, :name => "testfilter1") }
+      let!(:portfolio_filter2) { create(:portfolio, :name => "testfilter2") }
 
       it 'returns only the id specified in the filter' do
         get "#{api}/portfolios?filter[id]=#{portfolio_id}", :headers => default_headers
@@ -198,7 +197,7 @@ describe 'Portfolios API' do
     end
 
     context "when restoring a portfolio with portfolio_items that were discarded previously" do
-      let!(:second_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :discarded_at => 1.minute.ago, :tenant_id => tenant.id) }
+      let!(:second_item) { create(:portfolio_item, :portfolio => portfolio, :discarded_at => 1.minute.ago) }
 
       before do
         portfolio.discard

--- a/spec/requests/progress_message_spec.rb
+++ b/spec/requests/progress_message_spec.rb
@@ -5,11 +5,10 @@ describe "ProgressMessageRequests", :type => :request do
     end
   end
 
-  let(:tenant) { create(:tenant) }
-  let(:order) { create(:order, :tenant_id => tenant.id) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123", :tenant_id => tenant.id) }
-  let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s, :tenant_id => tenant.id) }
+  let(:order) { create(:order) }
+  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => "123") }
+  let!(:progress_message) { create(:progress_message, :order_item_id => order_item.id.to_s) }
 
   context "v1.0" do
     describe "GET /order_items/:order_item_id/progress_messages" do

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -1,11 +1,5 @@
-describe 'Settings API' do
-  let!(:tenant) do
-    create(:tenant,
-           :settings => {
-             :icon             => "<svg rel='stylesheet'>image</svg>",
-             :default_workflow => "1"
-           })
-  end
+describe 'Settings API', :type => :request do
+  let!(:tenant) { create(:tenant) }
   let(:retreived_tenant) { Tenant.find(tenant.id) }
 
   context "when the user is a catalog admin" do

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::AddToOrder do
+describe Catalog::AddToOrder, :type => :service do
   let(:service_offering_ref) { "998" }
   let(:order) { create(:order) }
   let(:order_id) { order.id.to_s }

--- a/spec/services/catalog/approval_transition_spec.rb
+++ b/spec/services/catalog/approval_transition_spec.rb
@@ -9,16 +9,12 @@ describe Catalog::ApprovalTransition do
 
   let!(:order_item) do
     ManageIQ::API::Common::Request.with_request(req) do
-      create(:order_item,
-             :order_id          => order.id,
-             :portfolio_item_id => "1")
+      create(:order_item, :order => order)
     end
   end
 
   let(:approval) do
-    create(:approval_request,
-           :workflow_ref  => "1",
-           :order_item_id => order_item.id)
+    create(:approval_request, :workflow_ref  => "1", :order_item => order_item)
   end
 
   let(:order_item_transition) { described_class.new(order_item.id) }

--- a/spec/services/catalog/approval_transition_spec.rb
+++ b/spec/services/catalog/approval_transition_spec.rb
@@ -14,7 +14,7 @@ describe Catalog::ApprovalTransition do
   end
 
   let(:approval) do
-    create(:approval_request, :workflow_ref  => "1", :order_item => order_item)
+    create(:approval_request, :workflow_ref => "1", :order_item => order_item)
   end
 
   let(:order_item_transition) { described_class.new(order_item.id) }

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::CopyPortfolioItem do
+describe Catalog::CopyPortfolioItem, :type => :service do
   let(:portfolio) { create(:portfolio) }
   let(:portfolio2) { create(:portfolio) }
   let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
@@ -39,9 +39,8 @@ describe Catalog::CopyPortfolioItem do
       let(:params) { { :portfolio_item_id => portfolio_item.id, :portfolio_id => portfolio.id } }
       let!(:another_portfolio_item) do
         create(:portfolio_item,
-               :tenant_id    => tenant.id,
-               :portfolio_id => portfolio.id,
-               :name         => "Copy of #{portfolio_item.name}")
+               :portfolio => portfolio,
+               :name      => "Copy of #{portfolio_item.name}")
       end
 
       it "adds a (1) to the name if there is already a copy" do

--- a/spec/services/catalog/copy_portfolio_item_spec.rb
+++ b/spec/services/catalog/copy_portfolio_item_spec.rb
@@ -1,8 +1,7 @@
 describe Catalog::CopyPortfolioItem do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
-  let(:portfolio2) { create(:portfolio, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+  let(:portfolio) { create(:portfolio) }
+  let(:portfolio2) { create(:portfolio) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
 
   let(:copy_portfolio_item) { described_class.new(params).process }
 

--- a/spec/services/catalog/copy_portfolio_spec.rb
+++ b/spec/services/catalog/copy_portfolio_spec.rb
@@ -1,8 +1,7 @@
-describe Catalog::CopyPortfolio do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio_item1) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
-  let!(:portfolio_item2) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+describe Catalog::CopyPortfolio, :type => :service do
+  let(:portfolio) { create(:portfolio) }
+  let!(:portfolio_item1) { create(:portfolio_item, :portfolio => portfolio) }
+  let!(:portfolio_item2) { create(:portfolio_item, :portfolio => portfolio) }
 
   let(:copy_portfolio) { described_class.new(:portfolio_id => portfolio.id).process }
 
@@ -33,7 +32,7 @@ describe Catalog::CopyPortfolio do
     end
 
     context "copy when there is a copy already" do
-      let!(:another_portfolio) { create(:portfolio, :tenant_id => tenant.id, :name => "Copy of #{portfolio.name}") }
+      let!(:another_portfolio) { create(:portfolio, :name => "Copy of #{portfolio.name}") }
 
       it "adds a (1) to the name" do
         expect(new_portfolio.name).to eq "Copy (1) of #{portfolio.name}"

--- a/spec/services/catalog/create_approval_request_spec.rb
+++ b/spec/services/catalog/create_approval_request_spec.rb
@@ -1,12 +1,10 @@
-describe Catalog::CreateApprovalRequest do
+describe Catalog::CreateApprovalRequest, :type => :service do
   let(:create_approval_request) { described_class.new(order.id) }
 
-  let(:tenant) { create(:tenant) }
   let(:workflow_ref) { "1" }
-  let!(:order) { create(:order, :tenant_id => tenant.id) }
-  let!(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
-  let!(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :workflow_ref => workflow_ref, :tenant_id => tenant.id) }
-  let!(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => portfolio_item.id, :tenant_id => tenant.id) }
+  let!(:order) { order_item.order }
+  let!(:portfolio_item) { create(:portfolio_item, :workflow_ref => workflow_ref) }
+  let!(:order_item) { create(:order_item, :portfolio_item => portfolio_item) }
 
   let(:approval) { class_double(Approval).as_stubbed_const(:transfer_nested_constants => true) }
   let(:api_instance) { instance_double(ApprovalApiClient::RequestApi) }
@@ -69,7 +67,7 @@ describe Catalog::CreateApprovalRequest do
 
     context "#create_approval_request" do
       let(:request_out) { ApprovalApiClient::RequestOut.new(:workflow_id => "1", :id => 2) }
-      let(:approval_request) { create_approval_request.send(:create_approval_request, request_out) }
+      let(:approval_request) { create_approval_request.send(:create_approval_request, request_out, order_item) }
 
       it "returns an ApprovalRequest Object" do
         expect(approval_request.class.name).to eq "ApprovalRequest"

--- a/spec/services/catalog/create_icon_spec.rb
+++ b/spec/services/catalog/create_icon_spec.rb
@@ -22,10 +22,11 @@ describe Catalog::CreateIcon, :type => :service do
 
   describe "#process" do
     let!(:base_image) { Image.create(:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.svg")))) }
+    let(:portfolio_item) { create(:portfolio_item) }
 
     context "when there is not an image record" do
       let(:image_params) { {:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "miq_logo.svg")))} }
-      let(:params) { {:source_ref => "icon_ref", :source_id => "source_id" }.merge(image_params) }
+      let(:params) { {:source_ref => "icon_ref", :source_id => "source_id", :portfolio_item => portfolio_item}.merge(image_params) }
 
       it "creates a new image record" do
         expect(subject.process.icon.image_id).to_not eq base_image.id
@@ -36,7 +37,7 @@ describe Catalog::CreateIcon, :type => :service do
 
     context "when there is an image record" do
       let(:image_params) { {:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.svg")))} }
-      let(:params) { {:source_ref => "icon_ref", :source_id => "source_id"}.merge(image_params) }
+      let(:params) { {:source_ref => "icon_ref", :source_id => "source_id", :portfolio_item => portfolio_item}.merge(image_params) }
 
       it "uses the existing record" do
         expect(subject.process.icon.image_id).to eq base_image.id

--- a/spec/services/catalog/create_icon_spec.rb
+++ b/spec/services/catalog/create_icon_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::CreateIcon do
+describe Catalog::CreateIcon, :type => :service do
   let(:subject) { described_class.new(params) }
 
   shared_examples_for "#process icon after being created" do

--- a/spec/services/catalog/duplicate_image_spec.rb
+++ b/spec/services/catalog/duplicate_image_spec.rb
@@ -1,4 +1,4 @@
-describe Catalog::DuplicateImage do
+describe Catalog::DuplicateImage, :type => :service do
   let(:subject) { described_class.new(new_image) }
 
   shared_examples_for "#process when there is not a duplicate image" do

--- a/spec/services/catalog/next_name_spec.rb
+++ b/spec/services/catalog/next_name_spec.rb
@@ -1,8 +1,7 @@
-describe Catalog::NextName do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio) { create(:portfolio, :tenant_id => tenant.id) }
-  let(:portfolio_item) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
-  let(:portfolio_item2) { create(:portfolio_item, :portfolio_id => portfolio.id, :tenant_id => tenant.id) }
+describe Catalog::NextName, :type => :service do
+  let(:portfolio) { create(:portfolio) }
+  let(:portfolio_item) { create(:portfolio_item, :portfolio => portfolio) }
+  let(:portfolio_item2) { create(:portfolio_item, :portfolio => portfolio) }
 
   let(:next_name) { described_class.new(portfolio_item.id, portfolio.id).process.next_name }
 

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -1,6 +1,4 @@
-describe Catalog::OrderItemSanitizedParameters do
-  include ServiceSpecHelper
-
+describe Catalog::OrderItemSanitizedParameters, :type => :service do
   Plan = Struct.new(:name, :id, :description, :create_json_schema)
   let(:plan) { Plan.new("Plan A", "1", "Plan A", json_schema) }
   let(:api_instance) { double(:api_instance) }
@@ -12,12 +10,11 @@ describe Catalog::OrderItemSanitizedParameters do
   end
 
   let(:order_item) do
-    create(:order_item, :portfolio_item_id           => 100,
-                        :order_id                    => 45,
-                        :service_plan_ref            => service_plan_ref,
-                        :service_parameters          => service_parameters,
-                        :provider_control_parameters => { 'a' => 1 },
-                        :count                       => 1)
+    create(:order_item,
+           :service_plan_ref            => service_plan_ref,
+           :service_parameters          => service_parameters,
+           :provider_control_parameters => { 'a' => 1 },
+           :count                       => 1)
   end
 
   let(:service_parameters) do

--- a/spec/services/catalog/order_state_transition_spec.rb
+++ b/spec/services/catalog/order_state_transition_spec.rb
@@ -1,9 +1,8 @@
 describe Catalog::OrderStateTransition do
-  let(:tenant) { create(:tenant) }
-  let(:order) { create(:order, :tenant_id => tenant.id) }
+  let(:order) { create(:order) }
 
-  let(:order_item) { create(:order_item, :order_id => order.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
-  let(:order_item2) { create(:order_item, :order_id => order.id, :portfolio_item_id => "1", :tenant_id => tenant.id) }
+  let(:order_item) { create(:order_item, :order => order) }
+  let(:order_item2) { create(:order_item, :order => order) }
 
   describe "#process" do
     before do

--- a/spec/services/catalog/override_icon_spec.rb
+++ b/spec/services/catalog/override_icon_spec.rb
@@ -1,8 +1,7 @@
-describe Catalog::OverrideIcon do
-  let(:tenant) { create(:tenant) }
-  let!(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
-  let!(:icon1) { create(:icon, :tenant_id => tenant.id, :portfolio_item_id => portfolio_item.id) }
-  let!(:icon2) { create(:icon, :tenant_id => tenant.id) }
+describe Catalog::OverrideIcon, :type => :service do
+  let!(:portfolio_item) { create(:portfolio_item) }
+  let!(:icon1) { create(:icon, :portfolio_item => portfolio_item) }
+  let!(:icon2) { create(:icon) }
 
   describe "#process" do
     context "when overriding an icon" do

--- a/spec/services/catalog/soft_delete_restore_spec.rb
+++ b/spec/services/catalog/soft_delete_restore_spec.rb
@@ -1,6 +1,5 @@
-describe Catalog::SoftDeleteRestore do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id, :discarded_at => Time.current) }
+describe Catalog::SoftDeleteRestore, :type => :service do
+  let(:portfolio_item) { create(:portfolio_item, :discarded_at => Time.current) }
 
   describe "#process" do
     context "when restoring a soft-deleted record" do

--- a/spec/services/catalog/soft_delete_spec.rb
+++ b/spec/services/catalog/soft_delete_spec.rb
@@ -1,6 +1,5 @@
-describe Catalog::SoftDelete do
-  let(:tenant) { create(:tenant) }
-  let(:portfolio_item) { create(:portfolio_item, :tenant_id => tenant.id) }
+describe Catalog::SoftDelete, :type => :service do
+  let(:portfolio_item) { create(:portfolio_item) }
 
   describe "#process" do
     context "when soft-deleting a record" do

--- a/spec/services/catalog/update_icon_spec.rb
+++ b/spec/services/catalog/update_icon_spec.rb
@@ -1,9 +1,9 @@
-describe Catalog::UpdateIcon do
+describe Catalog::UpdateIcon, :type => :service do
   let(:subject) { described_class.new(icon.id, params) }
 
   describe "#process" do
-    let(:image) { Image.create(:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.svg")))) }
-    let(:icon) { create(:icon, :source_ref => "127", :image_id => image.id) }
+    let(:image) { create(:image, :content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.svg")))) }
+    let(:icon) { create(:icon, :source_ref => "127", :image => image) }
 
     context "when updating an icon" do
       let(:params) do

--- a/spec/services/catalog/update_order_item_spec.rb
+++ b/spec/services/catalog/update_order_item_spec.rb
@@ -1,19 +1,16 @@
 require "manageiq-messaging"
 
-describe Catalog::UpdateOrderItem do
+describe Catalog::UpdateOrderItem, :type => :service do
   describe "#process" do
     let(:client) { double(:client) }
     let(:topic) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil, client, nil) }
     let(:payload) { {"task_id" => "123", "status" => status, "state" => state, "context" => "payloadcontext"} }
     let!(:item) do
       ManageIQ::API::Common::Request.with_request(default_request) do
-        create(:order_item,
-               :order_id          => order.id,
-               :topology_task_ref => topology_task_ref,
-               :portfolio_item_id => "1")
+        create(:order_item, :topology_task_ref => topology_task_ref)
       end
     end
-    let(:order) { create(:order) }
+    let(:order) { item.order }
     let(:subject) { described_class.new(topic) }
     let(:api_instance) { instance_double("TopologicalInventoryApiClient::DefaultApi") }
     let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceOffering::AddToPortfolioItem do
+describe ServiceOffering::AddToPortfolioItem, :type => :service do
   include ServiceOfferingHelper
   let(:api_instance) { double }
   let(:service_offering_ref) { "1" }

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -1,9 +1,13 @@
 module ServiceSpecHelper
   RSpec.configure do |config|
     config.around(:example, :type => :service) do |example|
+      default_tenant = Tenant.first_or_create!(:external_tenant => default_account_number)
+
       ActsAsTenant.with_tenant(default_tenant) do
         example.call
       end
+
+      Tenant.delete_all
     end
   end
 
@@ -23,9 +27,5 @@ module ServiceSpecHelper
 
   def default_request
     { :headers => default_headers, :original_url => original_url }
-  end
-
-  def default_tenant
-    Tenant.first_or_create!(:external_tenant => default_account_number)
   end
 end

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -1,7 +1,7 @@
 module ServiceSpecHelper
   RSpec.configure do |config|
     config.around(:example, :type => :service) do |example|
-      ActsAsTenant.with_tenant(tenant) do
+      ActsAsTenant.with_tenant(default_tenant) do
         example.call
       end
     end
@@ -25,7 +25,7 @@ module ServiceSpecHelper
     { :headers => default_headers, :original_url => original_url }
   end
 
-  def tenant
+  def default_tenant
     Tenant.first_or_create!(:external_tenant => default_account_number)
   end
 end

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -1,4 +1,12 @@
 module ServiceSpecHelper
+  RSpec.configure do |config|
+    config.around(:example, :type => :service) do |example|
+      ActsAsTenant.with_tenant(tenant) do
+        example.call
+      end
+    end
+  end
+
   def with_modified_env(options, &block)
     Thread.current[:api_instance] = nil
     ClimateControl.modify(options, &block)
@@ -15,5 +23,9 @@ module ServiceSpecHelper
 
   def default_request
     { :headers => default_headers, :original_url => original_url }
+  end
+
+  def tenant
+    Tenant.first_or_create!(:external_tenant => default_account_number)
   end
 end


### PR DESCRIPTION
~Still fixing specs...~

All specs should be fixed now! Any new service spec will need to have the `:type => :service` added to it to ensure that it makes use of passing through a tenant to better mimic real world conditions.

JIRA: https://projects.engineering.redhat.com/browse/SSP-734