### PR TITLE
Return order_item from AddToOrder instead of order

### DIFF
--- a/app/controllers/api/v1x0/order_items_controller.rb
+++ b/app/controllers/api/v1x0/order_items_controller.rb
@@ -13,7 +13,7 @@ module Api
 
       def create
         so = Catalog::AddToOrder.new(params)
-        render :json => so.process.order
+        render :json => so.process.order_item
       end
 
       def show

--- a/app/services/catalog/add_to_order.rb
+++ b/app/services/catalog/add_to_order.rb
@@ -1,14 +1,14 @@
 module Catalog
   class AddToOrder
-    attr_reader :order
+    attr_reader :order_item
 
     def initialize(params)
       @params = params
     end
 
     def process
-      @order = Order.find_by!(:id => @params[:order_id])
-      order.order_items << OrderItem.create!(order_item_params)
+      order = Order.find_by!(:id => @params[:order_id])
+      @order_item = order.order_items.create!(order_item_params)
       self
     end
 

--- a/spec/requests/order_items_spec.rb
+++ b/spec/requests/order_items_spec.rb
@@ -41,6 +41,19 @@ describe "OrderItemsRequests", :type => :request do
             expect(response).to have_http_status(:not_found)
           end
         end
+
+        context "after an order has an order item created under it" do
+          before do
+            ManageIQ::API::Common::Request.with_request(default_request) do
+              post "/api/v1.0/orders/#{order_3.id}/order_items", :headers => default_headers, :params => params
+            end
+          end
+
+          it "stores the x-rh-insights-id from the headers" do
+            get "/api/v1.0/orders/#{order_3.id}/order_items", :headers => default_headers
+            expect(json["data"].first["insights_request_id"]).to eq default_headers["x-rh-insights-request-id"]
+          end
+        end
       end
 
       it "list all order items by tenant" do
@@ -58,14 +71,14 @@ describe "OrderItemsRequests", :type => :request do
         end
       end
 
-      it "create an order item under an order" do
-        expect(response.content_type).to eq("application/json")
-        expect(response).to have_http_status(:ok)
+      it "creates an order item under an order" do
+        expect(json["order_id"]).to eq(order_3.id.to_s)
+        expect(json["service_parameters"]["name"]).to eq("fred")
       end
 
-      it "stores the x-rh-insights-id from the headers" do
-        get "/api/v1.0/orders/#{order_3.id}/order_items", :headers => default_headers
-        expect(json["data"].first["insights_request_id"]).to eq default_headers["x-rh-insights-request-id"]
+      it "returns a 200 with JSON content" do
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -64,23 +64,6 @@ describe "OrderRequests", :type => :request do
     end
   end
 
-  context "add to order" do
-    let(:svc_object) { instance_double("Catalog::AddToOrder") }
-    before do
-      allow(Catalog::AddToOrder).to receive(:new).and_return(svc_object)
-    end
-
-    it "successfully adds to an order" do
-      allow(svc_object).to receive(:process).and_return(svc_object)
-      allow(svc_object).to receive(:order).and_return(order)
-
-      post "/api/v1.0/orders/#{order.id}/order_items", :headers => default_headers
-
-      expect(response.content_type).to eq("application/json")
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
   context "list orders" do
     context "without filter" do
       before do

--- a/spec/services/catalog/add_to_order_spec.rb
+++ b/spec/services/catalog/add_to_order_spec.rb
@@ -21,7 +21,7 @@ describe Catalog::AddToOrder, :type => :service do
                                      'count'             => 1)
   end
 
-  let(:order_item) { described_class.new(params).process.order.order_items.first }
+  let(:order_item) { described_class.new(params).process.order_item }
 
   let(:request) { default_request }
 


### PR DESCRIPTION
As Benny pointed out, the object that is being returned from the API request to create an order item is an order, not the order item, so then another request is needed to query the order to see what the new order item ID is.

This PR should fix that, removes an unnecessary spec that we already have coverage on, and moves another spec intended for the `show` (though admittedly, after a create has happened).

https://projects.engineering.redhat.com/browse/SSP-741