### PR TITLE
Change Icon#create endpoint to use form data

### DIFF
--- a/app/controllers/api/v1x0/icons_controller.rb
+++ b/app/controllers/api/v1x0/icons_controller.rb
@@ -3,6 +3,9 @@ module Api
     class IconsController < ApplicationController
       include Api::V1x0::Mixins::IndexMixin
 
+      # Due to the fact form-data is getting uploaded and isn't supported by openapi_parser
+      skip_before_action :validate_request, :only => %i[create update]
+
       def show
         render :json => Icon.find(params.require(:id))
       end

--- a/app/services/catalog/create_icon.rb
+++ b/app/services/catalog/create_icon.rb
@@ -3,7 +3,7 @@ module Catalog
     attr_reader :icon
 
     def initialize(args)
-      @content = args.delete(:content)
+      @content = Base64.strict_encode64(File.read(args.delete(:content).tempfile))
       @params = args
     end
 

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -2,7 +2,6 @@ module ServiceOffering
   class AddToPortfolioItem
     include SourceMixin
     IGNORE_FIELDS = %w[id created_at updated_at portfolio_id tenant_id].freeze
-    ServiceOfferingIconFile = Struct.new(:tempfile)
 
     attr_reader :item
 
@@ -62,7 +61,7 @@ module ServiceOffering
       end
 
       svc = Catalog::CreateIcon.new(
-        :content        => ServiceOfferingIconFile.new(file),
+        :content        => OpenStruct.new(:tempfile => file),
         :source_ref     => service_offering_icon.source_ref,
         :source_id      => service_offering_icon.source_id,
         :portfolio_item => @item

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1634,9 +1634,15 @@
         "description": "Creates an Icon from the specified parameters",
         "requestBody": {
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Icon"
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
               }
             }
           }

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -40,7 +40,9 @@ describe "IconsRequests", :type => :request do
              :extension => "PNG")
     end
 
-    before { post "#{api}/icons", :params => params, :headers => default_headers }
+    before do
+      post "#{api}/icons", :params => params, :headers => default_headers, :as => :form
+    end
 
     context "when providing proper parameters" do
       let(:params) { {:content => form_upload_test_image("ocp_logo.svg"), :source_id => "27", :source_ref => "icon_ref", :portfolio_item_id => portfolio_item.id} }
@@ -134,7 +136,7 @@ describe "IconsRequests", :type => :request do
     let(:params) { {:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "miq_logo.svg"))) } }
 
     before do
-      patch "#{api}/icons/#{icon.id}", :params => params, :headers => default_headers
+      patch "#{api}/icons/#{icon.id}", :params => params, :headers => default_headers, :as => :form
       icon.reload
     end
 

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -43,7 +43,7 @@ describe "IconsRequests", :type => :request do
     before { post "#{api}/icons", :params => params, :headers => default_headers }
 
     context "when providing proper parameters" do
-      let(:params) { {:content => image.content, :source_id => "27", :source_ref => "icon_ref", :portfolio_item_id => portfolio_item.id} }
+      let(:params) { {:content => form_upload_test_image("ocp_logo.svg"), :source_id => "27", :source_ref => "icon_ref", :portfolio_item_id => portfolio_item.id} }
 
       it "returns a 200" do
         expect(response).to have_http_status(:ok)
@@ -56,7 +56,7 @@ describe "IconsRequests", :type => :request do
     end
 
     context "when uploading a duplicate svg icon" do
-      let(:params) { {:content => image.content, :source_id => "27", :source_ref => "icon_ref", :portfolio_item_id => portfolio_item.id} }
+      let(:params) { {:content => form_upload_test_image("ocp_logo.svg"), :source_id => "27", :source_ref => "icon_ref", :portfolio_item_id => portfolio_item.id} }
 
       it "uses the reference from the one that is already there" do
         expect(json["image_id"]).to eq image.id.to_s
@@ -66,7 +66,7 @@ describe "IconsRequests", :type => :request do
     context "when uploading a duplicate png icon" do
       let(:params) do
         {
-          :content           => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.png"))),
+          :content           => form_upload_test_image("ocp_logo_dupe.png"),
           :source_id         => "29",
           :source_ref        => "icon_ref",
           :portfolio_item_id => portfolio_item.id
@@ -81,7 +81,7 @@ describe "IconsRequests", :type => :request do
     context "when uploading a duplicate jpg icon" do
       let(:params) do
         {
-          :content           => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.jpg"))),
+          :content           => form_upload_test_image("ocp_logo_dupe.jpg"),
           :source_id         => "29",
           :source_ref        => "icon_ref",
           :portfolio_item_id => portfolio_item.id

--- a/spec/services/catalog/create_icon_spec.rb
+++ b/spec/services/catalog/create_icon_spec.rb
@@ -10,8 +10,8 @@ describe Catalog::CreateIcon, :type => :service do
     end
 
     it "points to the right image" do
-      expect(icon.image.extension).to eq Magick::Image.from_blob(Base64.decode64(image_params[:content])).first.format
-      expect(icon.image.content).to eq image_params[:content]
+      expect(icon.image.extension).to eq Magick::Image.from_blob(File.read(image_params[:content].tempfile)).first.format
+      expect(icon.image.content).to eq Base64.strict_encode64(File.read(image_params[:content].tempfile))
     end
 
     it "deletes the image related key from the params hash" do
@@ -25,7 +25,7 @@ describe Catalog::CreateIcon, :type => :service do
     let(:portfolio_item) { create(:portfolio_item) }
 
     context "when there is not an image record" do
-      let(:image_params) { {:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "miq_logo.svg")))} }
+      let(:image_params) { {:content => form_upload_test_image("miq_logo.svg")} }
       let(:params) { {:source_ref => "icon_ref", :source_id => "source_id", :portfolio_item => portfolio_item}.merge(image_params) }
 
       it "creates a new image record" do
@@ -36,7 +36,7 @@ describe Catalog::CreateIcon, :type => :service do
     end
 
     context "when there is an image record" do
-      let(:image_params) { {:content => Base64.strict_encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo_dupe.svg")))} }
+      let(:image_params) { {:content => form_upload_test_image("ocp_logo_dupe.svg")} }
       let(:params) { {:source_ref => "icon_ref", :source_id => "source_id", :portfolio_item => portfolio_item}.merge(image_params) }
 
       it "uses the existing record" do

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -28,4 +28,16 @@ module ServiceSpecHelper
   def default_request
     { :headers => default_headers, :original_url => original_url }
   end
+
+  def form_upload_test_image(filename)
+    filetype = case filename.split(".").last
+               when "svg"
+                 "image/svg+xml"
+               when "jpg"
+                 "image/jpg"
+               when "png"
+                 "image/png"
+               end
+    Rack::Test::UploadedFile.new(Rails.root.join("spec", "support", "images", filename), filetype)
+  end
 end


### PR DESCRIPTION
Found out the frontend can only send either form-data or blob, previously the `Icons#create` endpoint used a base64 encoded parameter with the file contents.

This PR just changes it to use a form upload for the `:content` parameter rather than a base64 encoded image. 