### PR TITLE
Remove validation for empty service plan and update logic to work without a service plan

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -9,9 +9,7 @@ class OrderItem < ApplicationRecord
   default_scope -> { kept }
 
   validates_presence_of :count
-  validates_presence_of :service_parameters
   validates_presence_of :order_id
-  validates_presence_of :service_plan_ref
   validates_presence_of :portfolio_item_id
 
   belongs_to :order

--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -39,7 +39,7 @@ module Catalog
     end
 
     def sanitized_parameters
-      return {} if service_plan_ref == "DNE"
+      return {} if service_plan_does_not_exist?
 
       svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
       fields.each_with_object({}) do |field, result|
@@ -56,6 +56,10 @@ module Catalog
 
     def fields
       service_plan_schema.dig(:schema, :fields) || []
+    end
+
+    def service_plan_does_not_exist?
+      service_plan_ref == Catalog::ServicePlans::SERVICE_PLAN_DOES_NOT_EXIST
     end
   end
 end

--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -39,6 +39,8 @@ module Catalog
     end
 
     def sanitized_parameters
+      return {} if service_plan_ref == "DNE"
+
       svc_params = ActiveSupport::HashWithIndifferentAccess.new(service_parameters)
       fields.each_with_object({}) do |field, result|
         value = mask_value?(field) ? MASKED_VALUE : svc_params[field[:name]]

--- a/app/services/catalog/order_item_sanitized_parameters.rb
+++ b/app/services/catalog/order_item_sanitized_parameters.rb
@@ -2,6 +2,7 @@ module Catalog
   class OrderItemSanitizedParameters
     MASKED_VALUE = "********".freeze
     FILTERED_PARAMS = %w[password token secret].freeze
+    SERVICE_PLAN_DOES_NOT_EXIST = "DNE".freeze
 
     def initialize(params)
       @params = params
@@ -59,7 +60,7 @@ module Catalog
     end
 
     def service_plan_does_not_exist?
-      service_plan_ref == Catalog::ServicePlans::SERVICE_PLAN_DOES_NOT_EXIST
+      service_plan_ref == SERVICE_PLAN_DOES_NOT_EXIST
     end
   end
 end

--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -1,5 +1,7 @@
 module Catalog
   class ServicePlans
+    SERVICE_PLAN_DOES_NOT_EXIST = "DNE".freeze
+
     attr_reader :items
     def initialize(portfolio_item_id)
       @portfolio_item_id = portfolio_item_id
@@ -38,7 +40,7 @@ module Catalog
       [{
         'service_offering_id' => ref,
         'description'         => "Description",
-        'id'                  => "DNE",
+        'id'                  => SERVICE_PLAN_DOES_NOT_EXIST,
         'create_json_schema'  => {
           'type'       => 'object',
           'properties' => {}

--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -9,7 +9,7 @@ module Catalog
       ref = PortfolioItem.find(@portfolio_item_id).service_offering_ref
       TopologicalInventory.call do |api_instance|
         result = api_instance.list_service_offering_service_plans(ref)
-        @items = filter_result(result.data)
+        @items = filter_result(result.data, ref)
       end
       self
     rescue StandardError => e
@@ -17,15 +17,33 @@ module Catalog
       raise
     end
 
-    def filter_result(result)
-      result.collect do |obj|
-        {
-          'name'               => obj.name,
-          'description'        => obj.description,
-          'id'                 => obj.id,
-          'create_json_schema' => obj.create_json_schema
-        }
+    private
+
+    def filter_result(result, ref)
+      if result.empty?
+        no_service_plan(ref)
+      else
+        result.collect do |obj|
+          {
+            'name'               => obj.name,
+            'description'        => obj.description,
+            'id'                 => obj.id,
+            'create_json_schema' => obj.create_json_schema
+          }
+        end
       end
+    end
+
+    def no_service_plan(ref)
+      [{
+        'service_offering_id' => ref,
+        'description'         => "Description",
+        'id'                  => "DNE",
+        'create_json_schema'  => {
+          'type'       => 'object',
+          'properties' => {}
+        }
+      }]
     end
   end
 end

--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -1,18 +1,21 @@
 module Catalog
   class ServicePlans
-    SERVICE_PLAN_DOES_NOT_EXIST = "DNE".freeze
+    include Catalog::JsonSchemaReader
 
     attr_reader :items
+
     def initialize(portfolio_item_id)
       @portfolio_item_id = portfolio_item_id
     end
 
     def process
-      ref = PortfolioItem.find(@portfolio_item_id).service_offering_ref
+      @reference = PortfolioItem.find(@portfolio_item_id).service_offering_ref
+
       TopologicalInventory.call do |api_instance|
-        result = api_instance.list_service_offering_service_plans(ref)
-        @items = filter_result(result.data, ref)
+        result = api_instance.list_service_offering_service_plans(@reference)
+        @items = filter_data(result.data)
       end
+
       self
     rescue StandardError => e
       Rails.logger.error("Service Plans #{e.message}")
@@ -21,31 +24,15 @@ module Catalog
 
     private
 
-    def filter_result(result, ref)
-      if result.empty?
-        no_service_plan(ref)
+    def filter_data(data)
+      if data.empty?
+        [read_json_schema("no_service_plan.erb")]
       else
-        result.collect do |obj|
-          {
-            'name'               => obj.name,
-            'description'        => obj.description,
-            'id'                 => obj.id,
-            'create_json_schema' => obj.create_json_schema
-          }
+        data.collect do |service_plan|
+          @service_plan = service_plan
+          read_json_schema("service_plan.erb")
         end
       end
-    end
-
-    def no_service_plan(ref)
-      [{
-        'service_offering_id' => ref,
-        'description'         => "Description",
-        'id'                  => SERVICE_PLAN_DOES_NOT_EXIST,
-        'create_json_schema'  => {
-          'type'       => 'object',
-          'properties' => {}
-        }
-      }]
     end
   end
 end

--- a/lib/catalog/json_schema_reader.rb
+++ b/lib/catalog/json_schema_reader.rb
@@ -1,0 +1,9 @@
+module Catalog
+  module JsonSchemaReader
+    def read_json_schema(filename)
+      template_file = File.read(Rails.root.join("schemas", "json", filename))
+
+      JSON.parse(ERB.new(template_file).result(binding))
+    end
+  end
+end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2745,6 +2745,12 @@
             "description": "The service plan description.",
             "readOnly": true
           },
+          "service_offering_id": {
+            "type": "string",
+            "title": "Service Offering ID",
+            "description": "The reference ID of the service offering",
+            "readOnly": true
+          },
           "id": {
             "type": "string",
             "title": "ID",

--- a/schemas/json/no_service_plan.erb
+++ b/schemas/json/no_service_plan.erb
@@ -1,0 +1,8 @@
+{
+  "service_offering_id": "<%= @reference %>",
+  "id": "DNE",
+  "create_json_schema": {
+    "type": "object",
+    "properties": {}
+  }
+}

--- a/schemas/json/service_plan.erb
+++ b/schemas/json/service_plan.erb
@@ -1,0 +1,7 @@
+{
+  "service_offering_id": "<%= @reference %>",
+  "id": "<%= @service_plan.id %>",
+  "create_json_schema": <%= @service_plan.create_json_schema %>,
+  "name": "<%= @service_plan.name %>",
+  "description": "<%= @service_plan.description %>"
+}

--- a/spec/services/catalog/order_item_sanitized_parameters_spec.rb
+++ b/spec/services/catalog/order_item_sanitized_parameters_spec.rb
@@ -1,94 +1,93 @@
 describe Catalog::OrderItemSanitizedParameters, :type => :service do
-  Plan = Struct.new(:name, :id, :description, :create_json_schema)
-  let(:plan) { Plan.new("Plan A", "1", "Plan A", json_schema) }
-  let(:api_instance) { double(:api_instance) }
-  let(:service_plan_ref) { "777" }
-  let(:oisp) do
-    with_modified_env :TOPOLOGY_SERVICE_URL => 'http://www.example.com' do
-      Catalog::OrderItemSanitizedParameters.new(params)
+  let(:subject) { described_class.new(params) }
+  let(:params) { ActionController::Parameters.new('order_item_id' => order_item.id) }
+
+  before do
+    allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+  end
+
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost") do
+      example.call
     end
-  end
-
-  let(:order_item) do
-    create(:order_item,
-           :service_plan_ref            => service_plan_ref,
-           :service_parameters          => service_parameters,
-           :provider_control_parameters => { 'a' => 1 },
-           :count                       => 1)
-  end
-
-  let(:service_parameters) do
-    { 'user'     => 'Fred Flintstone',
-      'password' => 'Yabba Dabba Doo',
-      'salary'   => 10_000_000,
-      'newpwd'   => 'Yabba Dabba Two',
-      'db_name'  => 'Slate Rocking Company' }
-  end
-
-  let(:params) do
-    ActionController::Parameters.new('order_item_id' => order_item.id)
-  end
-
-  let(:topological_inventory) do
-    class_double(TopologicalInventory).as_stubbed_const(:transfer_nested_constants => true)
   end
 
   describe "#process" do
-    before do
-      allow(topological_inventory).to receive(:call).and_yield(api_instance)
-      allow(api_instance).to receive(:show_service_plan).and_return(plan)
-      allow(plan).to receive(:create_json_schema).and_return(json_schema)
+    let(:order_item) { create(:order_item, :service_plan_ref => service_plan_ref) }
+
+    context "when there is a valid service_plan_ref" do
+      let(:service_plan_ref) { "777" }
+      let(:service_plan_response) do
+        TopologicalInventoryApiClient::ServicePlan.new(
+          :name               => "Plan A",
+          :id                 => "1",
+          :description        => "Plan A",
+          :create_json_schema => {:schema => {:fields => fields}}
+        )
+      end
+
+      before do
+        stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_plans/777")
+          .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+      end
+
+      context "ddf parameters" do
+        let(:fields) do
+          [{
+            :name         => "Totally not a pass",
+            :type         => "password",
+            :label        => "Totally not a pass",
+            :component    => "text-field",
+            :helperText   => "",
+            :isRequired   => true,
+            :initialValue => ""
+          }, {
+            :name         => "most_important_var1",
+            :label        => "secret field 1",
+            :component    => "textarea-field",
+            :helperText   => "Has no effect on anything, ever.",
+            :initialValue => ""
+          }, {
+            :name         => "token idea",
+            :label        => "field 1",
+            :component    => "textarea-field",
+            :helperText   => "Don't look.",
+            :initialValue => ""
+          }]
+        end
+
+        context "when the api call is successful" do
+          it "returns 3 masked values" do
+            result = subject.process
+
+            expect(result.values.select { |v| v == described_class::MASKED_VALUE }.count).to eq(3)
+          end
+        end
+
+        context "when the api call is not successful" do
+          before do
+            stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_plans/777")
+              .to_raise(TopologicalInventoryApiClient::ApiError)
+          end
+
+          it "handles the exception and reraises a StandardError" do
+            expect { subject.process }.to raise_error(StandardError)
+          end
+        end
+      end
     end
 
-    context "ddf parameters" do
-      let(:json_schema) do
-        {
-          :schema => {
-            :fields => [
-              {
-                :name         => "Totally not a pass",
-                :type         => "password",
-                :label        => "Totally not a pass",
-                :component    => "text-field",
-                :helperText   => "",
-                :isRequired   => true,
-                :initialValue => ""
-              },
-              {
-                :name         => "most_important_var1",
-                :label        => "secret field 1",
-                :component    => "textarea-field",
-                :helperText   => "Has no effect on anything, ever.",
-                :initialValue => ""
-              },
-              {
-                :name         => "token idea",
-                :label        => "field 1",
-                :component    => "textarea-field",
-                :helperText   => "Don't look.",
-                :initialValue => ""
-              }
-            ]
-          }
-        }
+    context "when the service plan ref is 'DNE'" do
+      let(:service_plan_ref) { "DNE" }
+      let(:fields) { [] }
+
+      it "does not call the api" do
+        subject.process
+        expect(a_request(:any, /localhost/)).not_to have_been_made
       end
 
-      it "success scenario" do
-        expect(api_instance).to receive(:show_service_plan)
-          .with(order_item.service_plan_ref)
-          .and_return(plan)
-
-        result = oisp.process
-
-        expect(result.values.select { |v| v == described_class::MASKED_VALUE }.count).to eq(3)
-      end
-
-      it "failure scenario" do
-        expect(api_instance).to receive(:show_service_plan)
-          .with(order_item.service_plan_ref)
-          .and_raise(TopologicalInventoryApiClient::ApiError.new("Kaboom"))
-
-        expect { oisp.process }.to raise_error(StandardError)
+      it "returns an empty hash" do
+        expect(subject.process).to eq({})
       end
     end
   end

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -23,6 +23,7 @@ describe Catalog::ServicePlans, :type => :service do
     end
 
     context "when there are service plans based on the service offering" do
+      let(:items) { service_plans.process.items }
       let(:plan1) do
         TopologicalInventoryApiClient::ServicePlan.new(
           :name               => "Plan A",
@@ -41,9 +42,28 @@ describe Catalog::ServicePlans, :type => :service do
       end
       let(:data) { [plan1, plan2] }
 
-      it "fetches the array of plans" do
-        expect(service_plans.process.items.count).to eq(2)
-        expect(service_plans.process.items.first["name"]).to eq("Plan A")
+      it "returns an array with two objects" do
+        expect(items.count).to eq(2)
+      end
+
+      it "returns an array with the first object with an ID of '1'" do
+        expect(items.first["id"]).to eq("1")
+      end
+
+      it "returns an array with the first object with a service_offering_id" do
+        expect(items.first["service_offering_id"]).to eq("998")
+      end
+
+      it "returns an array with the first object with a create json schema" do
+        expect(items.first["create_json_schema"]).to eq({})
+      end
+
+      it "returns an array with the first object with its name" do
+        expect(items.first["name"]).to eq("Plan A")
+      end
+
+      it "returns an array with the first object with its description" do
+        expect(items.first["description"]).to eq("Plan A")
       end
     end
 
@@ -65,6 +85,14 @@ describe Catalog::ServicePlans, :type => :service do
 
       it "returns an array with one object with a relatively empty create_json_schema" do
         expect(items.first["create_json_schema"]).to eq("type" => "object", "properties" => {})
+      end
+
+      it "returns an array with one object without a name" do
+        expect(items.first["name"]).to be_nil
+      end
+
+      it "returns an array with one object without a description" do
+        expect(items.first["description"]).to be_nil
       end
     end
 

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -1,29 +1,80 @@
-describe Catalog::ServicePlans do
+describe Catalog::ServicePlans, :type => :service do
   let(:service_offering_ref) { "998" }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
   let(:params) { portfolio_item.id }
   let(:service_plans) { described_class.new(params) }
-  let(:api_instance) { double }
-  let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }
 
   before do
-    allow(ti_class).to receive(:call).and_yield(api_instance)
+    allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
   end
 
-  it "fetches the array of plans" do
-    SvcPlan = Struct.new(:name, :id, :description, :create_json_schema)
-    plan1 = SvcPlan.new("Plan A", "1", "Plan A", {})
-    plan2 = SvcPlan.new("Plan B", "2", "Plan B", {})
-    result = double('links' => {}, 'meta' => {}, 'data' => [plan1, plan2])
-    expect(api_instance).to receive(:list_service_offering_service_plans).with(portfolio_item.service_offering_ref).and_return(result)
-
-    expect(service_plans.process.items.count).to eq(2)
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost") do
+      example.call
+    end
   end
 
-  context "invalid portfolio item" do
-    let(:params) { 1 }
-    it "raises exception" do
-      expect { service_plans.process }.to raise_error(ActiveRecord::RecordNotFound)
+  describe "#process" do
+    let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => data) }
+
+    before do
+      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/998/service_plans")
+        .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+    end
+
+    context "when there are service plans based on the service offering" do
+      let(:plan1) do
+        TopologicalInventoryApiClient::ServicePlan.new(
+          :name               => "Plan A",
+          :id                 => "1",
+          :description        => "Plan A",
+          :create_json_schema => {}
+        )
+      end
+      let(:plan2) do
+        TopologicalInventoryApiClient::ServicePlan.new(
+          :name               => "Plan B",
+          :id                 => "2",
+          :description        => "Plan B",
+          :create_json_schema => {}
+        )
+      end
+      let(:data) { [plan1, plan2] }
+
+      it "fetches the array of plans" do
+        expect(service_plans.process.items.count).to eq(2)
+        expect(service_plans.process.items.first["name"]).to eq("Plan A")
+      end
+    end
+
+    context "when there are no service plans based on the service offering" do
+      let(:data) { [] }
+      let(:items) { service_plans.process.items }
+
+      it "returns an array with one object" do
+        expect(items.count).to eq(1)
+      end
+
+      it "returns an array with one object with an ID of 'DNE'" do
+        expect(items.first["id"]).to eq("DNE")
+      end
+
+      it "returns an array with one object with a service_offering_id" do
+        expect(items.first["service_offering_id"]).to eq("998")
+      end
+
+      it "returns an array with one object with a relatively empty create_json_schema" do
+        expect(items.first["create_json_schema"]).to eq("type" => "object", "properties" => {})
+      end
+    end
+
+    context "invalid portfolio item" do
+      let(:params) { 1 }
+      let(:data) { [] }
+
+      it "raises exception" do
+        expect { service_plans.process }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end


### PR DESCRIPTION
Now that topology sends us back an empty result set if there are no service plans, we cannot validate the presence of `service_parameters` or a `service_plan_ref` on an `order_item`.

When requesting to order a service offering now, however, the UI is still expecting some kind of ID for the `service_plan_ref`. Since it doesn't actually matter, I've opted to simply use `"DNE"`, and then when we see this ref we simply return an empty hash for the sanitized parameters. If we wanted to change how the UI works, we could potentially simply look for the [`"service_offering_id"`](https://github.com/ManageIQ/catalog-api/pull/392/files#diff-2c52a0117cb7ba6fa405e2e812f51bd0R39) in the response since I've included that in place of the [service plan's name](https://github.com/ManageIQ/catalog-api/pull/392/files#diff-2c52a0117cb7ba6fa405e2e812f51bd0R28).

A lot of the changes are in the specs because the previous versions did not use webmock, so I had to adjust a lot of the logic in there to use webmock instead.

Related to https://projects.engineering.redhat.com/browse/SSP-680

@syncrou @lindgrenj6 Please Review.