### PR TITLE
First round cleanup to enable validation from openapi

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -16,8 +16,8 @@ module Api
           render :json => ManageIQ::API::Common::PaginatedResponse.new(
             :base_query => filtered(scoped(base_query)),
             :request    => request,
-            :limit      => pagination_params[:limit],
-            :offset     => pagination_params[:offset]
+            :limit      => params[:limit],
+            :offset     => params[:offset]
           ).response
         end
 
@@ -30,10 +30,6 @@ module Api
             ids = access_obj.id_list
             ids.any? ? relation.where(:id => ids) : relation
           end
-        end
-
-        def pagination_params
-          params.permit(:limit, :offset)
         end
 
         def filtered(base_query)

--- a/app/controllers/api/v1x0/portfolio_items_controller.rb
+++ b/app/controllers/api/v1x0/portfolio_items_controller.rb
@@ -72,7 +72,7 @@ module Api
       end
 
       def portfolio_item_patch_params
-        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref)
+        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url, :workflow_ref, :id, :service_offering_source_ref)
       end
 
       def portfolio_copy_params

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -354,7 +354,6 @@ describe "PortfolioItemRequests", :type => :request do
       end
 
       it 'returns a 422' do
-        response.body
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-757
These changes are to faciliate the catalog to use the
validation from the manageiq-api-common gem along with
deriving the strong parameters from the openapi spec.