### PR TITLE
Add new error formatting for client classes (per IPP)

### DIFF
--- a/app/controllers/api/v1/tenants_controller.rb
+++ b/app/controllers/api/v1/tenants_controller.rb
@@ -12,8 +12,6 @@ module Api
       def seed
         seeded = Group::Seed.new(Tenant.scoped_tenants.find(params.require(:tenant_id))).process
         json_response(nil, seeded.status)
-      rescue Catalog::NotAuthorized => e
-        json_response({:errors => e.message }, :forbidden)
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,9 @@ module Catalog
       "Catalog::NotAuthorized"             => :forbidden,
       "Catalog::OrderUncancelable"         => :unprocessable_entity,
       "Catalog::TopologyError"             => :service_unavailable,
+      "Catalog::ApprovalError"             => :service_unavailable,
+      "Catalog::SourcesError"              => :service_unavailable,
+      "Catalog::RBACError"                 => :service_unavailable,
       "Discard::DiscardError"              => :unprocessable_entity
     )
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -1,7 +1,7 @@
 describe "PortfolioItemRequests", :type => :request do
   around do |example|
     bypass_rbac do
-      with_modified_env(:APPROVAL_URL => "http://localhost") { example.call }
+      with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost", :APPROVAL_URL => "http://localhost") { example.call }
     end
   end
 
@@ -213,16 +213,11 @@ describe "PortfolioItemRequests", :type => :request do
   end
 
   context "v1.0 provider control parameters" do
-    let(:svc_object)  { instance_double("Catalog::ProviderControlParameters") }
-    let(:url)         { "#{api}/portfolio_items/#{portfolio_item.id}/provider_control_parameters" }
-
-    before do
-      allow(Catalog::ProviderControlParameters).to receive(:new).with(portfolio_item.id.to_s).and_return(svc_object)
-    end
+    let(:url) { "#{api}/portfolio_items/#{portfolio_item.id}/provider_control_parameters" }
 
     it "fetches plans" do
-      allow(svc_object).to receive(:process).and_return(svc_object)
-      allow(svc_object).to receive(:data).and_return(:fred => 'bedrock')
+      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/sources/568/container_projects")
+        .to_return(:status => 200, :body => {:data => [:name => 'fred']}.to_json, :headers => {"Content-type" => "application/json"})
 
       get url, :headers => default_headers
 
@@ -231,7 +226,8 @@ describe "PortfolioItemRequests", :type => :request do
     end
 
     it "raises error" do
-      allow(svc_object).to receive(:process).and_raise(topo_ex)
+      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/sources/568/container_projects")
+        .to_return(:status => 404, :body => "", :headers => {"Content-type" => "application/json"})
 
       get url, :headers => default_headers
 


### PR DESCRIPTION
Continuing the work that was done in #340 when we were discussing that the error messages didn't match up with the IPP.

- https://github.com/ManageIQ/manageiq-api-common/pull/114
- Still follows the status codes we set in `config/application.rb` via the ExceptionWrapper rescue_responses