### PR TITLE
Use the request validator for common gem

### DIFF
--- a/app/controllers/api/v1x0/settings_controller.rb
+++ b/app/controllers/api/v1x0/settings_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1x0
     class SettingsController < ApplicationController
+      skip_before_action :validate_primary_collection_id
+
       before_action do
         role_check("Catalog Administrator")
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::API
   include Response
   include Api::V1x0::Mixins::RBACMixin
+  include ManageIQ::API::Common::ApplicationControllerMixins::ApiDoc
+  include ManageIQ::API::Common::ApplicationControllerMixins::Common
+  include ManageIQ::API::Common::ApplicationControllerMixins::RequestBodyValidation
+  include ManageIQ::API::Common::ApplicationControllerMixins::RequestPath
 
   around_action :with_current_request
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,7 @@
 class ErrorsController < ApplicationController
+  self.openapi_enabled = false
+  skip_before_action :validate_primary_collection_id
+
   def not_found
     @exception = request.env["action_dispatch.exception"]
     Rails.logger.error(@exception.message)

--- a/app/controllers/internal/v0/notify_controller.rb
+++ b/app/controllers/internal/v0/notify_controller.rb
@@ -1,6 +1,9 @@
 module Internal
   module V0
     class NotifyController < ::ApplicationController
+      skip_before_action :validate_primary_collection_id
+      self.openapi_enabled = false
+
       def notify_approval_request
         request_id = params.require(:request_id)
         payload = params.require(:payload)

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -70,7 +70,7 @@ describe "PortfolioItemRequests", :type => :request do
   describe "POST /portfolios/:portfolio_id/portfolio_items" do
     let(:params) { {:portfolio_item_id => portfolio_item_id} }
     before do
-      post "#{api}/portfolios/#{portfolio.id}/portfolio_items", :params => params, :headers => default_headers, :as => :json
+      post "#{api}/portfolios/#{portfolio.id}/portfolio_items", :params => params, :headers => default_headers
     end
 
     it 'returns a 200' do
@@ -103,7 +103,7 @@ describe "PortfolioItemRequests", :type => :request do
   end
 
   describe 'POST /portfolio_items/{portfolio_item_id}/undelete' do
-    let(:undelete) { post "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :params => { :restore_key => restore_key }, :headers => default_headers, :as => :json }
+    let(:undelete) { post "#{api}/portfolio_items/#{portfolio_item_id}/undelete", :params => { :restore_key => restore_key }, :headers => default_headers }
     let(:restore_key) { Digest::SHA1.hexdigest(portfolio_item.discarded_at.to_s) }
 
     context "when restoring a portfolio_item that has been discarded" do
@@ -166,7 +166,7 @@ describe "PortfolioItemRequests", :type => :request do
     it "returns not found when topology doesn't have the service_offering_ref" do
       allow(add_to_portfolio_svc).to receive(:process).and_raise(topo_ex)
 
-      post "#{api}/portfolio_items", :params => params, :headers => default_headers, :as => :json
+      post "#{api}/portfolio_items", :params => params, :headers => default_headers
       expect(response).to have_http_status(:service_unavailable)
     end
 
@@ -174,7 +174,7 @@ describe "PortfolioItemRequests", :type => :request do
       allow(add_to_portfolio_svc).to receive(:process).and_return(add_to_portfolio_svc)
       allow(add_to_portfolio_svc).to receive(:item).and_return(portfolio_item)
 
-      post "#{api}/portfolio_items", :params => params, :headers => default_headers, :as => :json
+      post "#{api}/portfolio_items", :params => params, :headers => default_headers
       expect(response).to have_http_status(:ok)
       expect(json["id"]).to eq portfolio_item.id.to_s
       expect(json["owner"]).to eq portfolio_item.owner
@@ -244,7 +244,7 @@ describe "PortfolioItemRequests", :type => :request do
         stub_request(:get, "http://localhost/api/approval/v1.0/workflows/PatchWorkflowRef")
           .to_return(:status => 200, :body => "", :headers => {"Content-type" => "application/json"})
 
-        patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => valid_attributes, :headers => default_headers, :as => :json
+        patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => valid_attributes, :headers => default_headers
       end
 
       it 'returns a 200' do
@@ -258,7 +258,7 @@ describe "PortfolioItemRequests", :type => :request do
 
     context "when passing in read-only attributes" do
       before do
-        patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => invalid_attributes, :headers => default_headers, :as => :json
+        patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => invalid_attributes, :headers => default_headers
       end
 
       xit 'returns a 200' do
@@ -290,7 +290,7 @@ describe "PortfolioItemRequests", :type => :request do
 
   describe "copying portfolio items" do
     let(:copy_portfolio_item) do
-      post "#{api("1.0")}/portfolio_items/#{portfolio_item.id}/copy", :params => params, :headers => default_headers, :as => :json
+      post "#{api("1.0")}/portfolio_items/#{portfolio_item.id}/copy", :params => params, :headers => default_headers
     end
 
     context "when copying into the same portfolio" do
@@ -378,7 +378,7 @@ describe "PortfolioItemRequests", :type => :request do
 
     context "when adding an icon to a portfolio_item" do
       before do
-        post "#{api}/portfolio_items/#{portfolio_item.id}/icon", :params => { :icon_id => icon.id.to_s }, :headers => default_headers, :as => :json
+        post "#{api}/portfolio_items/#{portfolio_item.id}/icon", :params => { :icon_id => icon.id.to_s }, :headers => default_headers
       end
 
       it "returns a 200" do

--- a/spec/requests/portfolios_rbac_spec.rb
+++ b/spec/requests/portfolios_rbac_spec.rb
@@ -81,18 +81,21 @@ describe 'Portfolios RBAC API' do
   end
 
   context "when the permissions array is malformed" do
-    it "errors on a blank array" do
-      post "#{api}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => {:permissions => []}
+    # TODO: enable this once we get the openapi parser fixed
+    xit "errors on a blank array" do
+      params = {:permissions => [], :group_uuids => ['1'] }
+      post "#{api}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => params
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to match(/the value is empty/)
     end
 
     it "errors when the object is not an array" do
-      permissions = 1
-      post "#{api}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => { :permissions => permissions }
+      params = {:permissions => 1, :group_uuids => ['1'] }
+      post "#{api}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => params
 
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to match(/should be an array/)
+      expect(response).to have_http_status(:bad_request)
+      expect(json['errors'][0]['detail']).to match(/class is Integer/)
     end
   end
 

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -118,7 +118,7 @@ describe 'Portfolios API' do
       end
 
       it 'allows adding portfolios with the same name when one is discarded' do
-        post "#{api}/portfolios", :headers => default_headers, :params => valid_attributes, :as => :json
+        post "#{api}/portfolios", :headers => default_headers, :params => valid_attributes
 
         expect(response).to have_http_status(:ok)
       end
@@ -152,7 +152,7 @@ describe 'Portfolios API' do
 
     context "when restoring a portfolio" do
       before do
-        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params, :as => :json
+        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params
       end
 
       it "returns a 200" do
@@ -170,7 +170,7 @@ describe 'Portfolios API' do
 
       before do
         portfolio.discard
-        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params, :as => :json
+        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params
       end
 
       it "returns a 403" do
@@ -190,7 +190,7 @@ describe 'Portfolios API' do
       end
 
       it 'reports errors when undiscarding the child portfolio_items fails' do
-        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params, :as => :json
+        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -204,7 +204,7 @@ describe 'Portfolios API' do
       end
 
       it "only undeletes the one that was discarded at the same time as the portfolio" do
-        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params, :as => :json
+        post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params
 
         second_item.reload
         expect(second_item.discarded?).to be_truthy
@@ -217,7 +217,7 @@ describe 'Portfolios API' do
     let(:invalid_attributes) { { :fred => 'nope', :bob => 'bob portfolio' } }
     context 'when patched portfolio is valid' do
       before do
-        patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => valid_attributes, :as => :json
+        patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => valid_attributes
       end
 
       it 'returns status code 200' do
@@ -233,7 +233,7 @@ describe 'Portfolios API' do
 
     context 'when patched portfolio params are invalid' do
       before do
-        patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => invalid_attributes, :as => :json
+        patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => invalid_attributes
       end
 
       xit 'returns status code 200' do
@@ -251,7 +251,7 @@ describe 'Portfolios API' do
   describe 'POST /portfolios' do
     let(:valid_attributes) { { :name => 'rspec 1', :description => 'rspec 1 description' } }
     context 'when portfolio attributes are valid' do
-      before { post "#{api}/portfolios", :params => valid_attributes, :headers => default_headers, :as => :json }
+      before { post "#{api}/portfolios", :params => valid_attributes, :headers => default_headers }
 
       it 'returns status code 200' do
         expect(response).to have_http_status(200)
@@ -262,7 +262,7 @@ describe 'Portfolios API' do
       end
 
       it 'returns a status code 422 when trying to create with the same name' do
-        post "#{api}/portfolios", :params => valid_attributes, :headers => default_headers, :as => :json
+        post "#{api}/portfolios", :params => valid_attributes, :headers => default_headers
 
         expect(response).to have_http_status(422)
       end
@@ -290,7 +290,7 @@ describe 'Portfolios API' do
                      :permissions   => permissions,
                      :group_uuids   => group_uuids}
           allow(RBAC::ShareResource).to receive(:new).with(options).and_return(dummy)
-          post "#{api}/portfolios/#{portfolio.id}/share", :params => attributes, :headers => default_headers, :as => :json
+          post "#{api}/portfolios/#{portfolio.id}/share", :params => attributes, :headers => default_headers
           expect(response).to have_http_status(http_status)
         end
       end
@@ -303,7 +303,7 @@ describe 'Portfolios API' do
 
     context 'bad permissions' do
       include_context "sharing_objects"
-      let(:http_status) { '422' }
+      let(:http_status) { '400' }
 
       context 'invalid verb in permissions' do
         let(:permissions) { %w[catalog:portfolios:something] }
@@ -349,7 +349,7 @@ describe 'Portfolios API' do
                      :permissions   => permissions,
                      :group_uuids   => group_uuids}
           expect(RBAC::UnshareResource).to receive(:new).with(options).and_return(dummy)
-          post "#{api}/portfolios/#{portfolio.id}/unshare", :params => unsharing_attributes, :headers => default_headers, :as => :json
+          post "#{api}/portfolios/#{portfolio.id}/unshare", :params => unsharing_attributes, :headers => default_headers
           expect(response).to have_http_status(204)
         end
       end
@@ -374,7 +374,7 @@ describe 'Portfolios API' do
 
     context "copy without specifying name" do
       before do
-        post "#{api}/portfolios/#{portfolio.id}/copy", :headers => default_headers, :as => :json
+        post "#{api}/portfolios/#{portfolio.id}/copy", :headers => default_headers
       end
 
       it "returns a 200" do
@@ -404,7 +404,7 @@ describe 'Portfolios API' do
       let(:params) { { :portfolio_name => "NameyMcNameFace" } }
 
       before do
-        post "#{api}/portfolios/#{portfolio.id}/copy", :params => params, :headers => default_headers, :as => :json
+        post "#{api}/portfolios/#{portfolio.id}/copy", :params => params, :headers => default_headers
       end
 
       it "sets the name properly" do


### PR DESCRIPTION
This changes the 422 error codes to 400 (bad request)
This also sets the action_on_unpermitted_parameters to raise from the common gem so if any parameters is missing it will raise an error
https://github.com/ManageIQ/manageiq-api-common/blob/3848da0e2e6ec1395326d182cc97491620d0f668/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb#L10

Part of https://projects.engineering.redhat.com/browse/SSP-757