### PR TITLE
Utilize JsonSchemaReader to populate provider_control_parameter json

### DIFF
--- a/schemas/json/openshift_control_parameters.erb
+++ b/schemas/json/openshift_control_parameters.erb
@@ -9,10 +9,7 @@
 		"namespace": {
 			"type": "string",
 			"title": "OpenShift Project",
-			"enum": [
-					"default"
-				]
+			"enum": <%= @project_names %>
 		}
 	}
-
 }


### PR DESCRIPTION
Piggybacking on the changes made for https://github.com/ManageIQ/catalog-api/pull/392 with regards to the `JsonSchemaReader`, this PR should help clean up the provider control parameter service.

I also refactored the spec to utilize webmock.

@syncrou @lindgrenj6 Please Review.