### PR TITLE
Add text component when no service plan exists

### DIFF
--- a/schemas/json/no_service_plan.erb
+++ b/schemas/json/no_service_plan.erb
@@ -1,8 +1,14 @@
 {
   "service_offering_id": "<%= @reference %>",
   "id": "DNE",
-  "create_json_schema": {
-    "type": "object",
-    "properties": {}
-  }
+  "create_json_schema": <%= {
+    "schemaType": "default",
+    "schema": {
+      "fields": [{
+        "component": "plain-text",
+        "name": "empty-service-plan",
+        "label": "This product requires no user input and is fully configured by the system.\nClick submit to order this item."
+      }]
+    }
+  }.to_json %>
 }

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -83,8 +83,12 @@ describe Catalog::ServicePlans, :type => :service do
         expect(items.first["service_offering_id"]).to eq("998")
       end
 
-      it "returns an array with one object with a relatively empty create_json_schema" do
-        expect(items.first["create_json_schema"]).to eq("type" => "object", "properties" => {})
+      it "returns an array with one object with a specific plain text create json schema" do
+        json_schema = items.first["create_json_schema"]
+        expect(json_schema["schemaType"]).to eq("default")
+        expect(json_schema["schema"]["fields"].first["component"]).to eq("plain-text")
+        expect(json_schema["schema"]["fields"].first["name"]).to eq("empty-service-plan")
+        expect(json_schema["schema"]["fields"].first["label"]).to match("requires no user input")
       end
 
       it "returns an array with one object without a name" do


### PR DESCRIPTION
At the request of @Hyperkid123, the response to come back from an empty service plan should have a text component instead of a relatively empty `create_json_schema`.

https://projects.engineering.redhat.com/browse/SSP-797