### PR TITLE
Add request_completed_at to approval requests and update on completion

### DIFF
--- a/app/services/catalog/notify_approval_request.rb
+++ b/app/services/catalog/notify_approval_request.rb
@@ -15,7 +15,7 @@ module Catalog
     def process
       return self unless request_complete?
 
-      update_state
+      update_approval_request
       Catalog::ApprovalTransition.new(@notification_object.order_item.id).process
 
       self
@@ -27,7 +27,7 @@ module Catalog
       COMPLETED_EVENTS.include?(@message)
     end
 
-    def update_state
+    def update_approval_request
       case @message
       when EVENT_REQUEST_CANCELED
         state = "canceled"
@@ -35,7 +35,11 @@ module Catalog
         state = @payload["decision"]
       end
 
-      @notification_object.update(:state => state, :reason => @payload["reason"])
+      @notification_object.update(
+        :state                => state,
+        :reason               => @payload["reason"],
+        :request_completed_at => Time.now.utc
+      )
     end
   end
 end

--- a/db/migrate/20191002180129_add_request_completed_at_to_approval_requests.rb
+++ b/db/migrate/20191002180129_add_request_completed_at_to_approval_requests.rb
@@ -1,0 +1,5 @@
+class AddRequestCompletedAtToApprovalRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :approval_requests, :request_completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_10_203425) do
+ActiveRecord::Schema.define(version: 2019_10_02_180129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2019_09_10_203425) do
     t.string "reason"
     t.integer "state", default: 0
     t.bigint "tenant_id"
+    t.datetime "request_completed_at"
     t.index ["tenant_id"], name: "index_approval_requests_on_tenant_id"
   end
 

--- a/spec/services/catalog/notify_approval_request_spec.rb
+++ b/spec/services/catalog/notify_approval_request_spec.rb
@@ -29,6 +29,10 @@ describe Catalog::NotifyApprovalRequest do
           expect(approval_request.reason).to eq("because")
         end
 
+        it "updates the request completed at time" do
+          expect(approval_request.request_completed_at).to_not be_nil
+        end
+
         it "delegates to the approval transition" do
           expect(approval_transition).to have_received(:process)
         end
@@ -51,6 +55,10 @@ describe Catalog::NotifyApprovalRequest do
           expect(approval_request.reason).to eq("because")
         end
 
+        it "updates the request completed at time" do
+          expect(approval_request.request_completed_at).to_not be_nil
+        end
+
         it "delegates to the approval transition" do
           expect(approval_transition).to have_received(:process)
         end
@@ -71,6 +79,10 @@ describe Catalog::NotifyApprovalRequest do
 
         it "does not update the reason" do
           expect(approval_request.reason).to eq(nil)
+        end
+
+        it "does not update the request completed at time" do
+          expect(approval_request.request_completed_at).to eq(nil)
         end
 
         it "does not call the approval transition" do


### PR DESCRIPTION
@lgalis or @Hyperkid123 I think with the way this currently is, it will require a change in the [order-detail-table.js](https://github.com/ManageIQ/catalog-ui/blob/master/src/smart-components/order/order-detail-table.js) file to track this column. I didn't want to simply name it `updated_at` because that is slightly misleading and I feel doesn't fully capture the intent of the column, but also I don't want to make it unnecessarily difficult for you guys to have to deal with potentially different column names. Do either of you have thoughts on this? Should we simply use `updated_at` to make it easier for you guys, or is there a clean solution on your end that you can use to handle this new column?

https://projects.engineering.redhat.com/browse/SSP-778

@syncrou @lindgrenj6 Please Review.