### PR TITLE
Removed code since validation is done by openapi parser

### DIFF
--- a/app/controllers/api/v1x0/mixins/rbac_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/rbac_mixin.rb
@@ -27,31 +27,10 @@ module Api
           raise Catalog::NotAuthorized, "#{verb.titleize} access not authorized for #{klass}" unless access_obj.accessible?
         end
 
-        def permission_array_check(permissions)
-          invalid_parameter('Permission should be an array') unless permissions.kind_of?(Array)
-        end
-
         def role_check(role)
           return unless RBAC::Access.enabled?
 
           raise Catalog::NotAuthorized unless RBAC::Roles.assigned_role?(role)
-        end
-
-        private
-
-        def permission_format_check(permissions)
-          permissions.each do |perm|
-            invalid_parameter("Permission should be : delimited and contain app_name:resource:verb, where verb has to be one of #{VALID_RESOURCE_VERBS}") unless perm.kind_of?(String)
-            perm_list = perm.split(':')
-            invalid_parameter("Permission should be : delimited and contain app_name:resource:verb, where verb has to be one of #{VALID_RESOURCE_VERBS}") unless perm_list.length == 3
-            invalid_parameter("Permission app_name should be catalog") unless perm_list.first == 'catalog'
-            invalid_parameter("Only #{controller_name} objects can be shared") unless perm_list[1] == controller_name
-            invalid_parameter("Verbs should be one of #{VALID_RESOURCE_VERBS}") unless VALID_RESOURCE_VERBS.include?(perm_list[2])
-          end
-        end
-
-        def invalid_parameter(str)
-          raise Catalog::InvalidParameter, str
         end
       end
     end

--- a/app/controllers/api/v1x0/portfolios_controller.rb
+++ b/app/controllers/api/v1x0/portfolios_controller.rb
@@ -6,11 +6,6 @@ module Api
 
       before_action :write_access_check, :only => %i(add_portfolio_item_to_portfolio create update destroy)
       before_action :read_access_check, :only => %i(show)
-      before_action :only => %i[share unshare] do
-        permission_array_check(params.require(:permissions))
-        permission_format_check(params.require(:permissions))
-        group_id_array_check(params.require(:group_uuids))
-      end
 
       before_action :only => %i[copy] do
         resource_check('read', params.require(:portfolio_id))

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2951,6 +2951,7 @@
               "type": "string",
 	      "enum": ["catalog:portfolios:read", "catalog:portfolios:write", "catalog:portfolios:order"]
             },
+	    "minItems": 1,
             "example": ["catalog:portfolios:read", "catalog:portfolios:write", "catalog:portfolios:order"]
           },
           "group_uuids": {
@@ -2977,7 +2978,8 @@
             "items": {
               "type": "string",
 	      "enum": ["catalog:portfolios:read", "catalog:portfolios:write", "catalog:portfolios:order"]
-            }
+            },
+	    "minItems": 1
           },
           "group_uuids": {
             "type": "array",

--- a/spec/requests/portfolios_rbac_spec.rb
+++ b/spec/requests/portfolios_rbac_spec.rb
@@ -81,13 +81,12 @@ describe 'Portfolios RBAC API' do
   end
 
   context "when the permissions array is malformed" do
-    # TODO: enable this once we get the openapi parser fixed
-    xit "errors on a blank array" do
+    it "errors on a blank array" do
       params = {:permissions => [], :group_uuids => ['1'] }
       post "#{api}/portfolios/#{portfolio1.id}/share", :headers => default_headers, :params => params
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.body).to match(/the value is empty/)
+      expect(json['errors'][0]['detail']).to match(/cannot be less than min items/)
     end
 
     it "errors when the object is not an array" do


### PR DESCRIPTION
Renabled the array minimum items check since the openapi parser
was merged.
Added minItems for Permissions had earlier only added for group_uuids

https://github.com/ManageIQ/catalog-api/pull/387
https://projects.engineering.redhat.com/browse/SSP-763