### PR TITLE
When updating invalid parameters return 400

### DIFF
--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -261,16 +261,9 @@ describe "PortfolioItemRequests", :type => :request do
         patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => invalid_attributes, :headers => default_headers
       end
 
-      xit 'returns a 200' do
-        expect(response).to have_http_status(:ok)
-      end
-
-      xit 'updates the field that is allowed' do
-        expect(json["name"]).to eq invalid_attributes[:name]
-      end
-
-      xit "does not update the read-only field" do
-        expect(json["service_offering_ref"]).to_not eq invalid_attributes[:service_offering_ref]
+      it 'returns a 400' do
+        expect(response).to have_http_status(:bad_request)
+        expect(json['errors'][0]['detail']).to match(/required parameters display_name,service_offering_source_ref/)
       end
     end
 


### PR DESCRIPTION
The earlier spec was expecting that invalid parameters should
return a 200 and only update the attributes that are needed.
Extra attributes are ignored. Now that we have openapi parser
every parameter needs to be defined in the openapi.json.
Extra attributes lead to a 400 error.
Removed the specs which are no longer relevant.