### PR TITLE
Fixed an invalid parameter spec

### DIFF
--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -253,14 +253,9 @@ describe 'Portfolios API' do
         patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => invalid_attributes
       end
 
-      xit 'returns status code 200' do
-        expect(response).to have_http_status(200)
-      end
-
-      xit 'returns an updated portfolio object' do
-        expect(json).not_to be_empty
-        expect(json).to be_a Hash
-        expect(json['name']).to_not eq invalid_attributes[:name]
+      it 'returns status code 400' do
+        expect(response).to have_http_status(400)
+        expect(json['errors'][0]['detail']).to match(/required parameters name not exist/)
       end
     end
   end


### PR DESCRIPTION
Previously we were accepting invalid parameters for portfolio updates and returning a 200. Now with the new common gem validation we don't allow invalid arguments. Removed a spec that allows for updates with invalid parameters.