### PR TITLE
Added request_completed_at to ApprovalRequest

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2613,6 +2613,12 @@
             "description": "The reason for the current state.",
             "readOnly": true
           },
+          "request_completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Approval Request Completed At",
+            "readOnly": true
+          },
           "state": {
             "type": "string",
             "title": "State",


### PR DESCRIPTION
### Changes
- added request_completed_at to approval request schema

I tried to adjust UI after: https://github.com/ManageIQ/catalog-api/pull/411 and i've noticed that `request_completed_at` is not in response payload after running request at:
```
/order_items/{order_item_id}/approval_requests
```

If there is anything missing please let me know