### PR TITLE
Change GET raw_icon response to return 204 when no binary data present

### DIFF
--- a/app/controllers/api/v1/icons_controller.rb
+++ b/app/controllers/api/v1/icons_controller.rb
@@ -30,6 +30,9 @@ module Api
         send_data(image,
                   :type        => MimeMagic.by_magic(image).type,
                   :disposition => 'inline')
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.debug("Icon not found for params: #{params.keys.select { |key| key.end_with?("_id") }}")
+        head :no_content
       end
 
       def override_icon

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1481,17 +1481,14 @@
               }
             }
           },
+          "204": {
+            "description": "No icon present on Portfolio Item"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "description": "Icon Not Found/Not Present on Portfolio Item"
-          },
-          "500": {
-            "description": "Could not access the Topology Service"
           }
         }
       },
@@ -1757,14 +1754,14 @@
               }
             }
           },
+          "204": {
+            "description": "No icon data present."
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "description": "Icon Not Found."
           }
         }
       }

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -170,10 +170,16 @@ describe "IconsRequests", :type => :request do
     end
 
     context "when the icon does not exist" do
-      it "returns not found" do
+      it "/portfolio_items/{id}/icon returns no content" do
         get "#{api}/portfolio_items/0/icon", :headers => default_headers
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "/icons/{id}/icon_data returns no content" do
+        get "#{api}/icons/0/icon_data", :headers => default_headers
+
+        expect(response).to have_http_status(:no_content)
       end
     end
   end


### PR DESCRIPTION
Currently the logs are getting clouded when icons are not present on portfolio_items due to the fact that it throws a 404. This changes it to just return `:no_content` which is a bit more indicative of what is actually happening. 

cc @gmcculloug I know we talked about this a while back - finally got around to fixing it quick. 