### PR TITLE
Change copy portfolio behavior to use params[:portfolio_item_name] for name and display_name

### DIFF
--- a/app/services/catalog/copy_portfolio_item.rb
+++ b/app/services/catalog/copy_portfolio_item.rb
@@ -4,7 +4,7 @@ module Catalog
 
     def initialize(params)
       @portfolio_item = PortfolioItem.find(params[:portfolio_item_id])
-      @name = params[:portfolio_item_name] || @portfolio_item.display_name
+      @params = params
 
       begin
         @to_portfolio = Portfolio.find(params[:portfolio_id] || @portfolio_item.portfolio_id)
@@ -24,8 +24,8 @@ module Catalog
 
     def make_copy
       @portfolio_item.dup.tap do |new_portfolio_item|
-        new_portfolio_item.name = new_name(@portfolio_item.name, :name)
-        new_portfolio_item.display_name = new_name(@name, :display_name)
+        new_portfolio_item.name = @params[:portfolio_item_name] || new_name(@portfolio_item.name, :name)
+        new_portfolio_item.display_name = @params[:portfolio_item_name] || new_name(@portfolio_item.display_name, :display_name)
         new_portfolio_item.save
       end
     end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -330,6 +330,7 @@ describe "PortfolioItemRequests", :type => :request do
       it "returns the name specified" do
         copy_portfolio_item
         expect(json["display_name"]).to eq params[:portfolio_item_name]
+        expect(json["name"]).to eq params[:portfolio_item_name]
       end
     end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-698

Spoke with Benny about this, initially we were only updating the display_name of the portfolio item if `params[:portfolio_item_name]` was specified. When hitting this api directly though we should probably update the name as well as the display_name to keep things consistent. 