### PR TITLE
Allow for updates with partial set of attributes

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -125,7 +125,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Portfolio"
+                "$ref": "#/components/schemas/Portfolio",
+                "required": [
+                  "name"
+                ]
               }
             }
           },
@@ -612,7 +615,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PortfolioItem"
+                  "$ref": "#/components/schemas/PortfolioItem",
+                  "required": [
+                    "name",
+                    "display_name",
+                    "service_offering_source_ref"
+                  ]
                 }
               }
             }
@@ -2176,9 +2184,6 @@
     "schemas": {
       "Portfolio": {
         "type": "object",
-        "required": [
-          "name"
-        ],
         "properties": {
           "id": {
             "type": "string",
@@ -2332,11 +2337,6 @@
       },
       "PortfolioItem": {
         "type": "object",
-        "required": [
-          "name",
-          "display_name",
-          "service_offering_source_ref"
-        ],
         "properties": {
           "id": {
             "type": "string",

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -238,6 +238,7 @@ describe "PortfolioItemRequests", :type => :request do
   describe "patching portfolio items" do
     let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'PatchDescription', :workflow_ref => 'PatchWorkflowRef', :display_name => 'Test', 'service_offering_source_ref' => "27"} }
     let(:invalid_attributes) { { :name => 'PatchPortfolio', :service_offering_ref => "27" } }
+    let(:partial_attributes) { { :name => 'Curious George' } }
 
     context "when passing in valid attributes" do
       before do
@@ -263,7 +264,17 @@ describe "PortfolioItemRequests", :type => :request do
 
       it 'returns a 400' do
         expect(response).to have_http_status(:bad_request)
-        expect(json['errors'][0]['detail']).to match(/required parameters display_name,service_offering_source_ref/)
+        expect(json['errors'][0]['detail']).to match(/found unpermitted parameter: :service_offering_ref/)
+      end
+    end
+
+    context "when passing partial attributes" do
+      before do
+        patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => partial_attributes, :headers => default_headers
+      end
+
+      it 'returns a 200' do
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -215,6 +215,7 @@ describe 'Portfolios API' do
   describe 'PATCH /portfolios/:portfolio_id' do
     let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'description for patched portfolio', :workflow_ref => "123456" } }
     let(:invalid_attributes) { { :fred => 'nope', :bob => 'bob portfolio' } }
+    let(:partial_attributes) { { :name => 'Chef Pisghetti' } }
     context 'when patched portfolio is valid' do
       before do
         patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => valid_attributes
@@ -255,9 +256,21 @@ describe 'Portfolios API' do
 
       it 'returns status code 400' do
         expect(response).to have_http_status(400)
-        expect(json['errors'][0]['detail']).to match(/required parameters name not exist/)
+        expect(json['errors'][0]['detail']).to match(/found unpermitted parameters: :fred, :bob/)
       end
     end
+
+    context 'when patched portfolio params are partial' do
+      before do
+        patch "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => partial_attributes
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+        expect(json['name']).to eq(partial_attributes[:name])
+      end
+    end
+
   end
 
   describe 'POST /portfolios' do

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -270,7 +270,6 @@ describe 'Portfolios API' do
         expect(json['name']).to eq(partial_attributes[:name])
       end
     end
-
   end
 
   describe 'POST /portfolios' do


### PR DESCRIPTION
Allow for required parameters to be controlled outside of the object definition. This allows an object to be updated with a partial set of attributes.