### PR TITLE
Remove display_name validation

### DIFF
--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -7,7 +7,7 @@ class PortfolioItem < ApplicationRecord
 
   has_many :icons, :dependent => :destroy
   belongs_to :portfolio, :optional => true
-  validates :service_offering_ref, :name, :display_name, :presence => true
+  validates :service_offering_ref, :name, :presence => true
   validates :favorite_before_type_cast, :format => { :with => /\A(true|false)\z/i }, :allow_blank => true
 
   validate :validate_workflow, :if => proc { workflow_ref.present? }, :on => %i[create update]


### PR DESCRIPTION
The first step in allowing the UI to remove display_name and
not forcing it to run into validation issues for PortfolioItem operations

Related to https://github.com/ManageIQ/catalog-api/pull/428
Required by: https://github.com/ManageIQ/catalog-ui/pull/271