### PR TITLE
Use empty service plan template when survey_enabled setting is false

### DIFF
--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -12,8 +12,14 @@ module Catalog
       @reference = PortfolioItem.find(@portfolio_item_id).service_offering_ref
 
       TopologicalInventory.call do |api_instance|
-        result = api_instance.list_service_offering_service_plans(@reference)
-        @items = filter_data(result.data)
+        service_offering = api_instance.show_service_offering(@reference)
+
+        if JSON.parse(service_offering.extra)["survey_enabled"]
+          result = api_instance.list_service_offering_service_plans(@reference)
+          @items = filter_data(result.data)
+        else
+          @items = filter_data
+        end
       end
 
       self
@@ -24,7 +30,7 @@ module Catalog
 
     private
 
-    def filter_data(data)
+    def filter_data(data = [])
       if data.empty?
         [read_json_schema("no_service_plan.erb")]
       else

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -16,61 +16,18 @@ describe Catalog::ServicePlans, :type => :service do
 
   describe "#process" do
     let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => data) }
+    let(:service_offering_response) do
+      TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => survey_enabled}.to_json)
+    end
 
     before do
+      stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/998")
+        .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
       stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/998/service_plans")
         .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
     end
 
-    context "when there are service plans based on the service offering" do
-      let(:items) { service_plans.process.items }
-      let(:plan1) do
-        TopologicalInventoryApiClient::ServicePlan.new(
-          :name               => "Plan A",
-          :id                 => "1",
-          :description        => "Plan A",
-          :create_json_schema => {}
-        )
-      end
-      let(:plan2) do
-        TopologicalInventoryApiClient::ServicePlan.new(
-          :name               => "Plan B",
-          :id                 => "2",
-          :description        => "Plan B",
-          :create_json_schema => {"schema": {}}
-        )
-      end
-      let(:data) { [plan1, plan2] }
-
-      it "returns an array with two objects" do
-        expect(items.count).to eq(2)
-      end
-
-      it "returns an array with the first object with an ID of '1'" do
-        expect(items.first["id"]).to eq("1")
-      end
-
-      it "returns an array with the first object with a service_offering_id" do
-        expect(items.first["service_offering_id"]).to eq("998")
-      end
-
-      it "returns an array with the first object with a create json schema" do
-        expect(items.first["create_json_schema"]).to eq({})
-      end
-
-      it "returns an array with the first object with its name" do
-        expect(items.first["name"]).to eq("Plan A")
-      end
-
-      it "returns an array with the first object with its description" do
-        expect(items.first["description"]).to eq("Plan A")
-      end
-    end
-
-    context "when there are no service plans based on the service offering" do
-      let(:data) { [] }
-      let(:items) { service_plans.process.items }
-
+    shared_examples_for "#process when no service plan exists" do
       it "returns an array with one object" do
         expect(items.count).to eq(1)
       end
@@ -100,9 +57,82 @@ describe Catalog::ServicePlans, :type => :service do
       end
     end
 
+    context "when there are service plans based on the service offering" do
+      let(:items) { service_plans.process.items }
+      let(:plan1) do
+        TopologicalInventoryApiClient::ServicePlan.new(
+          :name               => "Plan A",
+          :id                 => "1",
+          :description        => "Plan A",
+          :create_json_schema => {}
+        )
+      end
+      let(:plan2) do
+        TopologicalInventoryApiClient::ServicePlan.new(
+          :name               => "Plan B",
+          :id                 => "2",
+          :description        => "Plan B",
+          :create_json_schema => {"schema" => {}}
+        )
+      end
+      let(:data) { [plan1, plan2] }
+
+      context "when the survey is enabled" do
+        let(:survey_enabled) { true }
+
+        it "returns an array with two objects" do
+          expect(items.count).to eq(2)
+        end
+
+        it "returns an array with the first object with an ID of '1'" do
+          expect(items.first["id"]).to eq("1")
+        end
+
+        it "returns an array with the first object with a service_offering_id" do
+          expect(items.first["service_offering_id"]).to eq("998")
+        end
+
+        it "returns an array with the first object with a create json schema" do
+          expect(items.first["create_json_schema"]).to eq({})
+        end
+
+        it "returns an array with the first object with its name" do
+          expect(items.first["name"]).to eq("Plan A")
+        end
+
+        it "returns an array with the first object with its description" do
+          expect(items.first["description"]).to eq("Plan A")
+        end
+      end
+
+      context "when the survey is disabled" do
+        let(:survey_enabled) { false }
+
+        it_behaves_like "#process when no service plan exists"
+      end
+    end
+
+    context "when there are no service plans based on the service offering" do
+      let(:data) { [] }
+      let(:items) { service_plans.process.items }
+
+      context "when the survey is enabled" do
+        let(:survey_enabled) { true }
+
+        it_behaves_like "#process when no service plan exists"
+      end
+
+      context "when the survey is disabled" do
+        let(:survey_enabled) { false }
+
+        it_behaves_like "#process when no service plan exists"
+      end
+    end
+
     context "invalid portfolio item" do
       let(:params) { 1 }
       let(:data) { [] }
+      let(:survey_enabled) { "doesn't matter" }
 
       it "raises exception" do
         expect { service_plans.process }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
Now that we have an empty service plan template for when there are no service plans, this PR will also make use of it for when the `survey_enabled` setting is false for a service offering attached to a portfolio item.

https://projects.engineering.redhat.com/browse/SSP-820

@syncrou Please Review (and/or tag others to review if necessary).