### PR TITLE
Add user to Catalog Administrator group when seeding

### DIFF
--- a/app/services/group/seed.rb
+++ b/app/services/group/seed.rb
@@ -1,6 +1,7 @@
 module Group
   class Seed
     attr_reader :status
+    CATALOG_ADMINISTRATOR_GROUP = "Catalog Administrators".freeze
 
     def initialize(tenant)
       @user = ManageIQ::API::Common::Request.current.user
@@ -26,7 +27,14 @@ module Group
     def process
       lookup_groups
       mark_as_seeded
-      @seeded.data.present? ? code(204) : run_seeding
+
+      if @seeded.data.present?
+        code(204)
+      else
+        run_seeding
+        add_user_to_catalog_admin_group
+      end
+
       self
     end
 
@@ -42,6 +50,27 @@ module Group
 
     def mark_as_seeded
       RbacSeed.find_or_create_by(:external_tenant => @user.tenant) if @seeded.data.present?
+    end
+
+    def add_user_to_catalog_admin_group
+      group_principal_in = RBACApiClient::GroupPrincipalIn.new.tap do |group|
+        group.principals = [RBACApiClient::PrincipalIn.new(:username => @user.username)]
+      end
+
+      ManageIQ::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+        api.add_principal_to_group(group_uuid(CATALOG_ADMINISTRATOR_GROUP), group_principal_in)
+      end
+    end
+
+    def group_uuid(group)
+      match = ManageIQ::API::Common::RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+        ManageIQ::API::Common::RBAC::Service.paginate(api, :list_groups, :name => group).detect do |grp|
+          group == grp.name
+        end
+      end
+      raise "Group Name: #{group} not found" unless match
+
+      match.uuid
     end
 
     def lookup_groups


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-818

When seeding RBAC we need to add the current user to the "Catalog Administrators" group. 

\### TODO: 
- [x] specs