### PR TITLE
Remove unnecessary JSON.parse for 'extra' service offering field

### DIFF
--- a/app/services/catalog/service_plans.rb
+++ b/app/services/catalog/service_plans.rb
@@ -14,7 +14,7 @@ module Catalog
       TopologicalInventory.call do |api_instance|
         service_offering = api_instance.show_service_offering(@reference)
 
-        if JSON.parse(service_offering.extra)["survey_enabled"]
+        if service_offering.extra[:survey_enabled]
           result = api_instance.list_service_offering_service_plans(@reference)
           @items = filter_data(result.data)
         else

--- a/spec/services/catalog/service_plans_spec.rb
+++ b/spec/services/catalog/service_plans_spec.rb
@@ -17,7 +17,7 @@ describe Catalog::ServicePlans, :type => :service do
   describe "#process" do
     let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => data) }
     let(:service_offering_response) do
-      TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => survey_enabled}.to_json)
+      TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => survey_enabled})
     end
 
     before do


### PR DESCRIPTION
So according to https://github.com/ManageIQ/topological_inventory-api-client-ruby/blob/master/docs/ServiceOffering.md, the `extra` field is a JSON object, so I figured we needed to parse it, but we don't.

https://projects.engineering.redhat.com/browse/SSP-825

@syncrou Please Review