### PR TITLE
Remove readOnly requirements for product attributes

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2651,25 +2651,21 @@
           },
           "long_description": {
             "type": "string",
-            "readOnly": true,
             "title": "Long Description",
             "example": "The longer description of a portfolio item"
           },
           "distributor": {
             "type": "string",
-            "readOnly": true,
             "title": "Distributor",
             "example": "The name of the provider for this Item"
           },
           "documentation_url": {
             "type": "string",
-            "readOnly": true,
             "title": "Documentation URL",
             "example": "The URL for documentation of the portfolio item"
           },
           "support_url": {
             "type": "string",
-            "readOnly": true,
             "title": "Support URL",
             "example": "The URL for finding support for the portfolio item"
           },


### PR DESCRIPTION
Tower does not include `long_description`, `distributor`, `documentation_url`, `support_url` as part of the default returned payload. Removing read only allows these attributes to stay nil.

JIRA: https://projects.engineering.redhat.com/browse/SSP-827