### PR TITLE
Add nullable true to all nullable PortfolioItem attributes

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2587,7 +2587,8 @@
           "description": {
             "type": "string",
             "title": "Description",
-            "example": "This is a sample description for a portfolio."
+            "example": "This is a sample description for a portfolio.",
+            "nullable": true
           },
           "enabled": {
             "type": "boolean",
@@ -2713,8 +2714,7 @@
           "favorite": {
             "type": "boolean",
             "title": "Favorite",
-            "example": "Definition of a favorite portfolio item",
-            "nullable": true
+            "example": "Definition of a favorite portfolio item"
           },
           "name": {
             "type": "string",
@@ -2837,18 +2837,21 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created at"
+            "title": "Created at",
+            "readOnly": true
           },
           "order_request_sent_at": {
             "type": "string",
             "format": "date-time",
             "title": "Order request sent at",
-            "description": "The time at which the order request was sent to the Topology Service"
+            "description": "The time at which the order request was sent to the Topology Service",
+            "nullable": true
           },
           "completed_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Completed at"
+            "title": "Completed at",
+            "readOnly": true
           },
           "owner": {
             "type": "string",

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2713,7 +2713,8 @@
           "favorite": {
             "type": "boolean",
             "title": "Favorite",
-            "example": "Definition of a favorite portfolio item"
+            "example": "Definition of a favorite portfolio item",
+            "nullable": true
           },
           "name": {
             "type": "string",
@@ -2723,7 +2724,8 @@
           "description": {
             "type": "string",
             "title": "Description",
-            "example": "Description of a portfolio item"
+            "example": "Description of a portfolio item",
+            "nullable": true
           },
           "orphan": {
             "type": "boolean",
@@ -2740,22 +2742,26 @@
           "long_description": {
             "type": "string",
             "title": "Long Description",
-            "example": "The longer description of a portfolio item"
+            "example": "The longer description of a portfolio item",
+            "nullable": true
           },
           "distributor": {
             "type": "string",
             "title": "Distributor",
-            "example": "The name of the provider for this Item"
+            "example": "The name of the provider for this Item",
+            "nullable": true
           },
           "documentation_url": {
             "type": "string",
             "title": "Documentation URL",
-            "example": "The URL for documentation of the portfolio item"
+            "example": "The URL for documentation of the portfolio item",
+            "nullable": true
           },
           "support_url": {
             "type": "string",
             "title": "Support URL",
-            "example": "The URL for finding support for the portfolio item"
+            "example": "The URL for finding support for the portfolio item",
+            "nullable": true
           },
           "workflow_ref": {
             "type": "string",

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,5 +1,5 @@
 describe "OpenAPI stuff" do
-  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons].freeze
+  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons service_plans].freeze
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
       r = ActionDispatch::Routing::RouteWrapper.new(route)
@@ -90,27 +90,31 @@ describe "OpenAPI stuff" do
     end
   end
 
-  describe "Parser Validatable attributes" do
+  describe "Openapi schema attributes" do
     PARSER_ATTRS = %w[readOnly nullable enum].freeze
     context "correctly configured" do
       ActiveRecord::Base.connection.tables.each do |table|
         next if SKIP_TABLES.include?(table)
 
         model_name = table.singularize.camelize
-        model = model_name.constantize
         doc = Api::Docs["1.0"].definitions
         doc[model_name].properties.keys.each do |attr|
           it "The JSON Schema #{model_name} #{attr} includes valid #{PARSER_ATTRS} types for #{doc[model_name].properties[attr]}" do
-            if model.validators_on(attr.to_sym).present? && !doc[model_name].key?("required")
+            # If there is a validator on the Activerecord model and the schema does not include the
+            #   'required' key
+            if model_name.constantize.validators_on(attr.to_sym).present? && !doc[model_name].key?("required")
               expect(doc[model_name].properties[attr].keys & PARSER_ATTRS).not_to include(attr)
+            # If there is a 'required' key on the schema
             elsif doc[model_name].key?("required")
               if doc[model_name]["required"].include?(attr)
-                expect(attr && doc[model_name]["required"]).to include(attr)
+                expect([attr] & doc[model_name]["required"]).to include(attr)
               else
-                expect(attr && doc[model_name]["required"]).not_to include(attr)
+                expect([attr] & doc[model_name]["required"]).not_to include(attr)
               end
+            # If we find the 'boolean' type
             elsif doc[model_name].properties[attr]['type'] == 'boolean'
               expect(doc[model_name].properties[attr].keys).not_to include(PARSER_ATTRS)
+            # Checking all the rest for PARSER_ATTRS
             else
               expect(doc[model_name].properties[attr].keys & PARSER_ATTRS).not_to be_empty
             end

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,4 +1,5 @@
 describe "OpenAPI stuff" do
+  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons]
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
       r = ActionDispatch::Routing::RouteWrapper.new(route)
@@ -89,10 +90,39 @@ describe "OpenAPI stuff" do
     end
   end
 
+  describe "Parser Validatable attributes" do
+    PARSER_ATTRS = %w[readOnly nullable enum].freeze
+    context "correctly configured" do
+      ActiveRecord::Base.connection.tables.each do |table|
+        next if SKIP_TABLES.include?(table)
+        model_name = table.singularize.camelize
+        model = model_name.constantize
+        doc = Api::Docs["1.0"].definitions
+        doc[model_name].properties.keys.each do |attr|
+          it "The JSON Schema #{model_name} #{attr} includes valid #{PARSER_ATTRS} types for #{doc[model_name].properties[attr]}" do
+            if model.validators_on(attr.to_sym).present? && !doc[model_name].keys.include?("required")
+              expect(doc[model_name].properties[attr].keys & PARSER_ATTRS).not_to include(attr)
+            elsif doc[model_name].keys.include?("required")
+              if doc[model_name]["required"].include?(attr)
+                expect(attr && doc[model_name]["required"]).to include(attr)
+              else
+                expect(attr && doc[model_name]["required"]).not_to include(attr)
+              end
+            elsif doc[model_name].properties[attr]['type'] == 'boolean'
+              expect(doc[model_name].properties[attr].keys).not_to include(PARSER_ATTRS)
+            else
+              expect(doc[model_name].properties[attr].keys & PARSER_ATTRS).not_to be_empty
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "Model serialization" do
     context "v1.0" do
       ActiveRecord::Base.connection.tables.each do |table|
-        next if %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons service_plans].include?(table)
+        next if SKIP_TABLES.include?(table)
 
         model_name = table.singularize.camelize
         model = model_name.constantize

--- a/spec/open_api_spec.rb
+++ b/spec/open_api_spec.rb
@@ -1,5 +1,5 @@
 describe "OpenAPI stuff" do
-  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons]
+  SKIP_TABLES = %w[tenants schema_migrations ar_internal_metadata rbac_seeds portfolio_tags portfolio_item_tags images icons].freeze
   let(:rails_routes) do
     Rails.application.routes.routes.each_with_object([]) do |route, array|
       r = ActionDispatch::Routing::RouteWrapper.new(route)
@@ -95,14 +95,15 @@ describe "OpenAPI stuff" do
     context "correctly configured" do
       ActiveRecord::Base.connection.tables.each do |table|
         next if SKIP_TABLES.include?(table)
+
         model_name = table.singularize.camelize
         model = model_name.constantize
         doc = Api::Docs["1.0"].definitions
         doc[model_name].properties.keys.each do |attr|
           it "The JSON Schema #{model_name} #{attr} includes valid #{PARSER_ATTRS} types for #{doc[model_name].properties[attr]}" do
-            if model.validators_on(attr.to_sym).present? && !doc[model_name].keys.include?("required")
+            if model.validators_on(attr.to_sym).present? && !doc[model_name].key?("required")
               expect(doc[model_name].properties[attr].keys & PARSER_ATTRS).not_to include(attr)
-            elsif doc[model_name].keys.include?("required")
+            elsif doc[model_name].key?("required")
               if doc[model_name]["required"].include?(attr)
                 expect(attr && doc[model_name]["required"]).to include(attr)
               else

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -14,6 +14,9 @@ describe "PortfolioItemRequests", :type => :request do
   let(:portfolio_item) do
     create(:portfolio_item, :service_offering_ref        => service_offering_ref,
                             :service_offering_source_ref => service_offering_source_ref,
+                            :description                 => "default description",
+                            :long_description            => "longer than description",
+                            :distributor                 => "Distributor CO",
                             :portfolio_id                => portfolio_id)
   end
   let(:portfolio_item_id)    { portfolio_item.id.to_s }
@@ -289,10 +292,10 @@ describe "PortfolioItemRequests", :type => :request do
       end
 
       it 'updates the field that is null' do
-        expect(json["workflow_ref"]).to eq nullable_attributes[:workflow_ref]
-        expect(json["description"]).to eq nullable_attributes[:description]
-        expect(json["distributor"]).to eq nullable_attributes[:distributor]
-        expect(json["long_description"]).to eq nullable_attributes[:long_description]
+        expect(json["workflow_ref"]).to be_nil
+        expect(json["description"]).to be_nil
+        expect(json["distributor"]).to be_nil
+        expect(json["long_description"]).to be_nil
       end
     end
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -279,7 +279,7 @@ describe "PortfolioItemRequests", :type => :request do
     end
 
     context "when passing in nullable attributes" do
-      let(:nullable_attributes) { { :name => 'PatchPortfolio', :description => nil, :long_description => nil, :distributor => nil,  :workflow_ref => nil} }
+      let(:nullable_attributes) { { :name => 'PatchPortfolio', :description => nil, :long_description => nil, :distributor => nil, :workflow_ref => nil} }
       before do
         patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => nullable_attributes, :headers => default_headers
       end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -279,7 +279,7 @@ describe "PortfolioItemRequests", :type => :request do
     end
 
     context "when passing in nullable attributes" do
-      let(:nullable_attributes) { { :name => 'PatchPortfolio', :description => 'PatchDescription', :workflow_ref => nil} }
+      let(:nullable_attributes) { { :name => 'PatchPortfolio', :description => nil, :long_description => nil, :distributor => nil,  :workflow_ref => nil} }
       before do
         patch "#{api}/portfolio_items/#{portfolio_item.id}", :params => nullable_attributes, :headers => default_headers
       end
@@ -290,6 +290,9 @@ describe "PortfolioItemRequests", :type => :request do
 
       it 'updates the field that is null' do
         expect(json["workflow_ref"]).to eq nullable_attributes[:workflow_ref]
+        expect(json["description"]).to eq nullable_attributes[:description]
+        expect(json["distributor"]).to eq nullable_attributes[:distributor]
+        expect(json["long_description"]).to eq nullable_attributes[:long_description]
       end
     end
 


### PR DESCRIPTION
Simply removing readOnly validation attributes was not enough,
the openapi parser gem requires a type is set when a param is passed through the validator.
Without any type set it defaults to the nil check and if nullable isn't there it fails

JIRA: https://projects.engineering.redhat.com/browse/SSP-828