### PR TITLE
Fix tag unique index and implement tagging unique fix from topo

### DIFF
--- a/app/models/concerns/acts_as_taggable_on.rb
+++ b/app/models/concerns/acts_as_taggable_on.rb
@@ -35,7 +35,7 @@ module ActAsTaggableOn
 
               tag_params = {:name => tag_name, :tenant_id => tenant.id}
               tag_params.merge!(options)
-              tag = Tag.create(tag_params)
+              tag = Tag.find_or_create_by(tag_params)
               tagging_params = {self.class.name.underscore.to_sym => self, :tag_id => tag.id}
               public_send(self.class.tagging_relation_name).create(tagging_params)
             end

--- a/db/migrate/20191024175018_change_index_on_tags.rb
+++ b/db/migrate/20191024175018_change_index_on_tags.rb
@@ -1,0 +1,6 @@
+class ChangeIndexOnTags < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :tags, :column => ["tenant_id", "namespace", "name"]
+    add_index :tags, ["tenant_id", "namespace", "name", "value"], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_164731) do
+ActiveRecord::Schema.define(version: 2019_10_24_175018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,7 +189,7 @@ ActiveRecord::Schema.define(version: 2019_10_22_164731) do
     t.string "namespace", default: "", null: false
     t.text "description"
     t.datetime "created_at", null: false
-    t.index ["tenant_id", "namespace", "name"], name: "index_tags_on_tenant_id_and_namespace_and_name", unique: true
+    t.index ["tenant_id", "namespace", "name", "value"], name: "index_tags_on_tenant_id_and_namespace_and_name_and_value", unique: true
   end
 
   create_table "tenants", force: :cascade do |t|

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -47,4 +47,42 @@ describe 'Tagging API' do
       expect(json["data"].first["name"]).to eq portfolio.name
     end
   end
+
+  describe "Multiple Tags" do
+    context "when only populating the name" do
+      it "re-uses the same tag in the database" do
+        portfolio.tag_add("Fred")
+        portfolio_item.tag_add("Fred")
+
+        portfolio_tag = portfolio.tags.where(:name => "Fred").first
+        portfolio_item_tag = portfolio_item.tags.where(:name => "Fred").first
+
+        expect(portfolio_tag.id).to eq portfolio_item_tag.id
+      end
+    end
+
+    context "when matching name, namespace, and value" do
+      it "re-uses the same tag in the database" do
+        portfolio.tag_add("Barney", :namespace => "catalog", :value => "yes")
+        portfolio_item.tag_add("Barney", :namespace => "catalog", :value => "yes")
+
+        portfolio_tag = portfolio.tags.where(:name => "Barney").first
+        portfolio_item_tag = portfolio_item.tags.where(:name => "Barney").first
+
+        expect(portfolio_tag.id).to eq portfolio_item_tag.id
+      end
+    end
+
+    context "when only matching name" do
+      it "does not re-use the tag in the database" do
+        portfolio.tag_add("Wilma", :namespace => "catalog", :value => "yes")
+        portfolio_item.tag_add("Wilma", :namespace => "catalog", :value => "no")
+
+        portfolio_tag = portfolio.tags.where(:name => "Wilma").first
+        portfolio_item_tag = portfolio_item.tags.where(:name => "Wilma").first
+
+        expect(portfolio_tag.id).not_to eq portfolio_item_tag.id
+      end
+    end
+  end
 end


### PR DESCRIPTION
A bug was found in topology when re-using multiple tags. 

This PR implements the same fix they did in https://github.com/ManageIQ/topological_inventory-core/pull/156 as well as fixing the unique index which I missed a column on. 