### PR TITLE
Expose an OrderItem object for add to order

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1353,7 +1353,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully added an item to order"
+            "description": "Successfully added an item to order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderItem"
+                }
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"


### PR DESCRIPTION
Per https://projects.engineering.redhat.com/browse/SSP-741

Exposing the `OrderItem` schema as a response to the `addToOrder` OperationID for:
`POST /orders/{order_id}/order_items`