### PR TITLE
Fix duplicate image spec failing on specific order

### DIFF
--- a/spec/services/catalog/duplicate_image_spec.rb
+++ b/spec/services/catalog/duplicate_image_spec.rb
@@ -19,7 +19,7 @@ describe Catalog::DuplicateImage, :type => :service do
 
   describe "#process" do
     let!(:base_image) { Image.create(:content => Base64.encode64(File.read(Rails.root.join("spec", "support", "images", "ocp_logo.#{extension}")))) }
-    let(:new_image) { Image.create(:content => Base64.encode64(File.read(Rails.root.join("spec", "support", "images", filename)))) }
+    let(:new_image) { Image.new(:content => Base64.encode64(File.read(Rails.root.join("spec", "support", "images", filename)))) }
 
     context "PNG Images" do
       let(:extension) { "png" }


### PR DESCRIPTION
https://travis-ci.org/ManageIQ/catalog-api/builds/602455246?utm_source=github_status&utm_medium=notification

Found a very specific spec failure that I can only reproduce on that specific seed AND when the database is fresh, resulting in this travis failure.

It was due to the fact that I accidentally used `Image.create` instead of `Image.new` like the `Catalog::DuplicateImage` service is expecting. This way it behaves as expected where it only persists the `image` if it is unique. 