### PR TITLE
The tenant_seed method doesn't need pagination parameters

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -767,15 +767,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/TenantID"
-          },
-          {
-            "$ref": "#/components/parameters/QueryLimit"
-          },
-          {
-            "$ref": "#/components/parameters/QueryOffset"
-          },
-          {
-            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {


### PR DESCRIPTION
Removed pagination parameters since they are not relevant during seeding. They are typically used on a GET call where we are expecting multiple records to be coming back.