### PR TITLE
Add `ServicePlan` list/show/create methods

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -5,9 +5,17 @@ module Api
 
       def index
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
-        Catalog::ImportServicePlans.new(portfolio_item.id).process if portfolio_item.service_plans.empty?
 
-        collection(portfolio_item.service_plans)
+        if portfolio_item.service_plans.empty?
+          render :json => Catalog::ServicePlans.new(portfolio_item.id).process.items
+        else
+          render :json => portfolio_item.service_plans
+        end
+      end
+
+      def create
+        svc = Catalog::ImportServicePlans.new(params.require(:portfolio_item_id))
+        render :json => svc.process.service_plans
       end
 
       def show

--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -4,8 +4,20 @@ module Api
       include Api::V1::Mixins::IndexMixin
 
       def index
-        so = Catalog::ServicePlans.new(params.require(:portfolio_item_id))
-        render :json => so.process.items
+        portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))
+        Catalog::ImportServicePlans.new(portfolio_item.id).process if portfolio_item.service_plans.empty?
+
+        collection(portfolio_item.service_plans)
+      end
+
+      def show
+        plan = ServicePlan.find(params.require(:id))
+        render :json => plan
+      end
+
+      def base
+        plan = ServicePlan.find(params.require(:service_plan_id))
+        render :json => plan.base
       end
     end
   end

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -9,7 +9,8 @@ module Catalog
     def process
       service_plan_schemas.each do |schema|
         ServicePlan.create!(
-          :base              => schema,
+          :base              => schema["create_json_schema"],
+          :modified          => schema["create_json_schema"],
           :portfolio_item_id => @portfolio_item.id
         )
       end
@@ -20,8 +21,7 @@ module Catalog
     end
 
     def service_plan_schemas
-      service_plans = Catalog::ServicePlans.new(@portfolio_item.id).process.items
-      service_plans.collect { |plan| plan["create_json_schema"] }
+      Catalog::ServicePlans.new(@portfolio_item.id).process.items
     end
   end
 end

--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -1,0 +1,27 @@
+module Catalog
+  class ImportServicePlans
+    attr_reader :service_plans
+
+    def initialize(portfolio_item_id)
+      @portfolio_item = PortfolioItem.find(portfolio_item_id)
+    end
+
+    def process
+      service_plan_schemas.each do |schema|
+        ServicePlan.create!(
+          :base              => schema,
+          :portfolio_item_id => @portfolio_item.id
+        )
+      end
+
+      @service_plans = @portfolio_item.service_plans
+
+      self
+    end
+
+    def service_plan_schemas
+      service_plans = Catalog::ServicePlans.new(@portfolio_item.id).process.items
+      service_plans.collect { |plan| plan["create_json_schema"] }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,9 @@ Rails.application.routes.draw do
       resources :tenants, :only => [:index, :show] do
         post 'seed', :to => 'tenants#seed'
       end
+      resources :service_plans, :only => [:show] do
+        get 'base', :to => 'service_plans#base'
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
       resources :tenants, :only => [:index, :show] do
         post 'seed', :to => 'tenants#seed'
       end
-      resources :service_plans, :only => [:show] do
+      resources :service_plans, :only => [:create, :show] do
         get 'base', :to => 'service_plans#base'
       end
     end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -995,7 +995,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServicePlansCollection"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServicePlan"
+                  }
                 }
               }
             }
@@ -2396,6 +2399,49 @@
         }
       }
     },
+    "/service_plans": {
+      "post": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Create Service Plan",
+        "operationId": "createServicePlan",
+        "description": "Returns the new Service Plan",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportServicePlan"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Service Plan",
+            "content": {
+              "application/json": {
+                "schema": {
+				  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServicePlan"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
+    },
     "/service_plans/{id}": {
       "get": {
         "tags": [
@@ -2712,6 +2758,17 @@
             "type": "string",
             "title": "Service Offering Ref",
             "description": "The service offering ref should be retrieved from a call to the Topology Service.",
+            "example": "177"
+          }
+        }
+      },
+      "ImportServicePlan": {
+        "type": "object",
+        "properties": {
+          "portfolio_item_id": {
+            "type": "string",
+            "title": "Portfolio Item ID",
+            "description": "The Portfolio Item to import the service plans for.",
             "example": "177"
           }
         }
@@ -3159,6 +3216,18 @@
       "ServicePlan": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the service plan.",
+            "readOnly": true
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "The service plan description.",
+            "readOnly": true
+          },
           "base": {
             "type": "object",
             "title": "base",
@@ -3299,23 +3368,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Tenant"
-            }
-          }
-        }
-      },
-      "ServicePlansCollection": {
-        "type": "object",
-        "properties": {
-          "meta": {
-            "$ref": "#/components/schemas/CollectionMetadata"
-          },
-          "links": {
-            "$ref": "#/components/schemas/CollectionLinks"
-          },
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ServicePlan"
             }
           }
         }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -995,10 +995,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ServicePlan"
-                  }
+                  "$ref": "#/components/schemas/ServicePlansCollection"
                 }
               }
             }
@@ -2398,6 +2395,91 @@
           }
         }
       }
+    },
+    "/service_plans/{id}": {
+      "get": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Show Service Plan",
+        "operationId": "showServicePlan",
+        "description": "Returns the specified Service Plan",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePlan"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
+    },
+    "/service_plans/{id}/base": {
+      "get": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Show Service Plan Base Schema",
+        "operationId": "showServicePlanBase",
+        "description": "Returns the specified Service Plan's base schema",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan Base Schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "schema": {
+                      "title": "example schema",
+                      "fields": [
+                        {
+                          "name": "example field"
+                        },
+                        {
+                          "label": "example field"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -3077,34 +3159,27 @@
       "ServicePlan": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "The name of the service plan.",
+          "base": {
+            "type": "object",
+            "title": "base",
+            "description": "The base schema imported from Topology",
             "readOnly": true
           },
-          "description": {
-            "type": "string",
-            "title": "Description",
-            "description": "The service plan description.",
-            "readOnly": true
+          "modified": {
+            "type": "object",
+            "title": "modified",
+            "description": "The modified schema for Catalog"
           },
-          "service_offering_id": {
+          "portfolio_item_id": {
             "type": "string",
-            "title": "Service Offering ID",
-            "description": "The reference ID of the service offering",
+            "title": "Portfolio Item ID",
+            "description": "The reference ID of the Portfolio Item",
             "readOnly": true
           },
           "id": {
             "type": "string",
             "title": "ID",
             "description": "The unique identifier for this service plan.",
-            "readOnly": true
-          },
-          "create_json_schema": {
-            "type": "object",
-            "title": "JSON Schema",
-            "description": "JSON schema for the object.",
             "readOnly": true
           }
         }
@@ -3224,6 +3299,23 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Tenant"
+            }
+          }
+        }
+      },
+      "ServicePlansCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServicePlan"
             }
           }
         }

--- a/spec/factories/service_plan.rb
+++ b/spec/factories/service_plan.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :service_plan, :traits => [:has_tenant] do
+    sequence(:base) do |n|
+      {
+        "schema" => {
+          :title       => "Factory Schema #{n}",
+          :description => "A Generated Schema #{n}"
+        }
+      }
+    end
+
+    modified { base }
+
+    portfolio_item
+  end
+end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -188,33 +188,6 @@ describe "PortfolioItemRequests", :type => :request do
     end
   end
 
-  context "service plans" do
-    let(:svc_object)           { instance_double("Catalog::ServicePlans") }
-    let(:plans)                { [{}, {}] }
-
-    before do
-      allow(Catalog::ServicePlans).to receive(:new).with(portfolio_item.id.to_s).and_return(svc_object)
-    end
-
-    it "fetches plans" do
-      allow(svc_object).to receive(:process).and_return(svc_object)
-      allow(svc_object).to receive(:items).and_return(plans)
-
-      get "/#{api}/portfolio_items/#{portfolio_item.id}/service_plans", :headers => default_headers
-
-      expect(JSON.parse(response.body).count).to eq(2)
-      expect(response.content_type).to eq("application/json")
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "raises error" do
-      allow(svc_object).to receive(:process).and_raise(topo_ex)
-
-      get "/#{api}/portfolio_items/#{portfolio_item.id}/service_plans", :headers => default_headers
-      expect(response).to have_http_status(:service_unavailable)
-    end
-  end
-
   context "v1.0 provider control parameters" do
     let(:url) { "#{api}/portfolio_items/#{portfolio_item.id}/provider_control_parameters" }
 

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -1,7 +1,7 @@
 describe "ServicePlansRequests", :type => :request do
-  let!(:service_plan) { create(:service_plan) }
-  let!(:portfolio_item) { service_plan.portfolio_item }
-  let!(:service_offering_ref) { portfolio_item.service_offering_ref }
+  let(:service_plan) { create(:service_plan) }
+  let(:portfolio_item) { service_plan.portfolio_item }
+  let(:service_offering_ref) { portfolio_item.service_offering_ref }
   let!(:portfolio_item_without_service_plan) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
 
   around do |example|
@@ -31,23 +31,28 @@ describe "ServicePlansRequests", :type => :request do
   end
 
   describe "#index" do
-    before do
-      get "#{api}/portfolio_items/#{portfolio_item_without_service_plan.id}/service_plans", :headers => default_headers
+    context "when there are service plans in the db" do
+      before do
+        post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+        get "#{api}/portfolio_items/#{portfolio_item_without_service_plan.id}/service_plans", :headers => default_headers
+      end
+
+      it "returns what we have in the db" do
+        db_plans = portfolio_item_without_service_plan.service_plans
+
+        expect(db_plans.count).to eq json.count
+        expect(db_plans.first.portfolio_item_id).to eq portfolio_item_without_service_plan.id
+      end
     end
 
-    it "returns a 200" do
-      expect(response).to have_http_status :ok
-    end
+    context "when there are not service plans in the db" do
+      before do
+        get "#{api}/portfolio_items/#{portfolio_item_without_service_plan.id}/service_plans", :headers => default_headers
+      end
 
-    it "imports the service plan" do
-      expect(portfolio_item_without_service_plan.service_plans.count).to eq 1
-    end
-
-    it "returns the newly created ServicePlan in an array" do
-      expect(json["meta"]["count"]).to eq 1
-      expect(json["data"].first["id"]).to eq portfolio_item_without_service_plan.service_plans.first.id.to_s
-      expect(json["data"].first["portfolio_item_id"]).to eq portfolio_item_without_service_plan.id.to_s
-      expect(json["data"].first["base"]).to eq portfolio_item_without_service_plan.service_plans.first.base
+      it "returns the newly created ServicePlan in an array" do
+        expect(json.first["create_json_schema"]).to eq topo_service_plan.create_json_schema
+      end
     end
   end
 
@@ -63,6 +68,20 @@ describe "ServicePlansRequests", :type => :request do
     it "returns the specified service_plan" do
       expect(json["id"]).to eq service_plan.id.to_s
       expect(json.keys).to match_array %w[base modified portfolio_item_id id]
+    end
+  end
+
+  describe "#create" do
+    before do
+      post "#{api}/service_plans", :headers => default_headers, :params => {:portfolio_item_id => portfolio_item_without_service_plan.id.to_s}
+    end
+
+    it "pulls in the service plans" do
+      expect(portfolio_item_without_service_plan.service_plans.count).to eq 1
+    end
+
+    it "returns the imported service plans" do
+      expect(json.first["id"]).to eq portfolio_item_without_service_plan.service_plans.first.id.to_s
     end
   end
 

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -1,0 +1,82 @@
+describe "ServicePlansRequests", :type => :request do
+  let!(:service_plan) { create(:service_plan) }
+  let!(:portfolio_item) { service_plan.portfolio_item }
+  let!(:service_offering_ref) { portfolio_item.service_offering_ref }
+  let!(:portfolio_item_without_service_plan) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost", :BYPASS_RBAC => 'true') do
+      example.call
+    end
+  end
+
+  let(:topo_service_plan) do
+    TopologicalInventoryApiClient::ServicePlan.new(
+      :name               => "The Plan",
+      :id                 => "1",
+      :description        => "A Service Plan",
+      :create_json_schema => {"schema" => {}}
+    )
+  end
+  let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => [topo_service_plan]) }
+  let(:service_offering_response) do
+    TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => true})
+  end
+
+  before do
+    stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/#{service_offering_ref}")
+      .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
+    stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/#{service_offering_ref}/service_plans")
+      .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+  end
+
+  describe "#index" do
+    before do
+      get "#{api}/portfolio_items/#{portfolio_item_without_service_plan.id}/service_plans", :headers => default_headers
+    end
+
+    it "returns a 200" do
+      expect(response).to have_http_status :ok
+    end
+
+    it "imports the service plan" do
+      expect(portfolio_item_without_service_plan.service_plans.count).to eq 1
+    end
+
+    it "returns the newly created ServicePlan in an array" do
+      expect(json["meta"]["count"]).to eq 1
+      expect(json["data"].first["id"]).to eq portfolio_item_without_service_plan.service_plans.first.id.to_s
+      expect(json["data"].first["portfolio_item_id"]).to eq portfolio_item_without_service_plan.id.to_s
+      expect(json["data"].first["base"]).to eq portfolio_item_without_service_plan.service_plans.first.base
+    end
+  end
+
+  describe "#show" do
+    before do
+      get "#{api}/service_plans/#{service_plan.id}", :headers => default_headers
+    end
+
+    it "returns a 200" do
+      expect(response).to have_http_status :ok
+    end
+
+    it "returns the specified service_plan" do
+      expect(json["id"]).to eq service_plan.id.to_s
+      expect(json.keys).to match_array %w[base modified portfolio_item_id id]
+    end
+  end
+
+  describe "#base" do
+    before do
+      get "#{api}/service_plans/#{service_plan.id}/base", :headers => default_headers
+    end
+
+    it "returns a 200" do
+      expect(response).to have_http_status :ok
+    end
+
+    it "returns the base schema from the service_plan" do
+      expect(json["schema"]).to eq service_plan.base["schema"]
+    end
+  end
+end

--- a/spec/services/catalog/import_service_plans_spec.rb
+++ b/spec/services/catalog/import_service_plans_spec.rb
@@ -1,0 +1,63 @@
+describe Catalog::ImportServicePlans, :type => :service do
+  let(:service_offering_ref) { "1" }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+  let(:subject) { described_class.new(portfolio_item.id) }
+
+  around do |example|
+    with_modified_env(:TOPOLOGICAL_INVENTORY_URL => "http://localhost") do
+      example.call
+    end
+  end
+
+  let(:service_plan) do
+    TopologicalInventoryApiClient::ServicePlan.new(
+      :name               => "The Plan",
+      :id                 => "1",
+      :description        => "A Service Plan",
+      :create_json_schema => {"schema" => {}}
+    )
+  end
+  let(:service_plan_response) { TopologicalInventoryApiClient::ServicePlansCollection.new(:data => data) }
+  let(:service_offering_response) do
+    TopologicalInventoryApiClient::ServiceOffering.new(:extra => {"survey_enabled" => true})
+  end
+
+  before do
+    allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(default_headers)
+
+    stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/1")
+      .to_return(:status => 200, :body => service_offering_response.to_json, :headers => default_headers)
+    stub_request(:get, "http://localhost/api/topological-inventory/v1.0/service_offerings/1/service_plans")
+      .to_return(:status => 200, :body => service_plan_response.to_json, :headers => default_headers)
+  end
+
+  describe "#process" do
+    before do
+      subject.process
+    end
+
+    context "when there is one plan" do
+      let(:data) { [service_plan] }
+
+      it "reaches out to topology twice" do
+        expect(a_request(:get, /topological-inventory\/v1.0\/service_offerings/)).to have_been_made.twice
+      end
+
+      it "adds the ServicePlan to the portfolio_item" do
+        expect(portfolio_item.service_plans.count).to eq 1
+      end
+    end
+
+    context "when there are multiple plans" do
+      let(:data) { [service_plan, service_plan.dup] }
+
+      it "reaches out to topology twice" do
+        expect(a_request(:get, /topological-inventory\/v1.0\/service_offerings/)).to have_been_made.twice
+      end
+
+      it "adds both the ServicePlans to the portfolio_item" do
+        expect(portfolio_item.service_plans.count).to eq 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-832

Adding the following methods:
- `GET /service_plans/:id` - show
- `GET /service_plans/:id/base` - show base schema
- `POST /service_plans` - import service plans

Modifying this endpoint to check if the service plan has been imported and if so  return it:
- `GET /portfolio_items/:portfolio_item_id/service_plans`

\# TODO:
- [x] OpenAPI JSON Schema changes
- [x] `Catalog::ImportServicePlan` service class
- [x] `GET /portfolio_items/:portfolio_item_id/service_plans`
- [x] `GET /service_plans/:id`
- [x] `GET /service_plans/:id/base`
- [x] specs for `ServicePlansController`
- [x] specs for `Catalog::ImportServicePlan` service class
