### PR TITLE
Add `Service Plan` PATCH modified

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -27,6 +27,13 @@ module Api
         plan = ServicePlan.find(params.require(:service_plan_id))
         render :json => plan.base
       end
+
+      def update_modified
+        plan = ServicePlan.find(params.require(:service_plan_id))
+        plan.update!(:modified => params.require(:modified))
+
+        render :json => plan.modified
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
       end
       resources :service_plans, :only => [:create, :show] do
         get 'base', :to => 'service_plans#base'
+        patch 'modified', :to => 'service_plans#update_modified'
       end
     end
   end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2526,6 +2526,55 @@
           }
         }
       }
+    },
+    "/service_plans/{id}/modified": {
+      "patch": {
+        "tags": [
+          "Service Plans"
+        ],
+        "summary": "Patch Service Plan Modified Schema",
+        "operationId": "patchServicePlanModified",
+        "description": "Returns the specified Service Plan's modified schema",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service Plan Modified Schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "schema": {
+                      "title": "example schema",
+                      "fields": [
+                        {
+                          "name": "example field"
+                        },
+                        {
+                          "label": "example field"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "Service Plan Not Found."
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/spec/requests/service_plans_spec.rb
+++ b/spec/requests/service_plans_spec.rb
@@ -98,4 +98,24 @@ describe "ServicePlansRequests", :type => :request do
       expect(json["schema"]).to eq service_plan.base["schema"]
     end
   end
+
+  describe "#modified" do
+    context "when patching the modified schema" do
+      let(:params) do
+        {:modified => service_plan.base.tap { |base| base["schema"][:new_field] = "a new field" }}
+      end
+
+      before do
+        patch "#{api}/service_plans/#{service_plan.id}/modified", :headers => default_headers, :params => params
+      end
+
+      it "returns a 200" do
+        expect(response).to have_http_status :ok
+      end
+
+      it "returns the newly modified schema from the service_plan" do
+        expect(json["schema"]["new_field"]).to eq params[:modified]["schema"][:new_field]
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-835

Adding endpoint:
`PATCH /service_plans/{service_plan_id}/modified`
With parameters: `:modified => {}`

Currently has no validations, they're being added in different PRs. 

#452 must go first.