### PR TITLE
Add `:name` and `:description` to Service Plans

### DIFF
--- a/app/services/catalog/import_service_plans.rb
+++ b/app/services/catalog/import_service_plans.rb
@@ -9,6 +9,8 @@ module Catalog
     def process
       service_plan_schemas.each do |schema|
         ServicePlan.create!(
+          :name              => schema["name"],
+          :description       => schema["description"],
           :base              => schema["create_json_schema"],
           :modified          => schema["create_json_schema"],
           :portfolio_item_id => @portfolio_item.id

--- a/db/migrate/20191104192052_add_name_and_description_to_service_plans.rb
+++ b/db/migrate/20191104192052_add_name_and_description_to_service_plans.rb
@@ -1,0 +1,6 @@
+class AddNameAndDescriptionToServicePlans < ActiveRecord::Migration[5.2]
+  def change
+    add_column :service_plans, :name, :string
+    add_column :service_plans, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_01_193710) do
+ActiveRecord::Schema.define(version: 2019_11_04_192052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,6 +174,8 @@ ActiveRecord::Schema.define(version: 2019_11_01_193710) do
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
+    t.string "description"
     t.index ["discarded_at"], name: "index_service_plans_on_discarded_at"
     t.index ["tenant_id"], name: "index_service_plans_on_tenant_id"
   end


### PR DESCRIPTION
Forgot to persist `name` and `description` on the Service Plan object that comes back from Topology in #442, this corrects that. 

Depends on #452 