### PR TITLE
Update OpenAPI Spec to use 400 instead of 422 for invalid requests

### DIFF
--- a/app/controllers/api/v1/portfolios_controller.rb
+++ b/app/controllers/api/v1/portfolios_controller.rb
@@ -33,8 +33,6 @@ module Api
       def create
         portfolio = Portfolio.create!(portfolio_params)
         render :json => portfolio
-      rescue ActiveRecord::RecordInvalid => e
-        render :json => { :errors => e.message }, :status => :unprocessable_entity
       end
 
       def update

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,18 +32,6 @@ module Catalog
 
     config.autoload_paths << Rails.root.join('lib').to_s
 
-    ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
-      "ActionController::ParameterMissing" => :unprocessable_entity,
-      "Catalog::InvalidParameter"          => :unprocessable_entity,
-      "Catalog::NotAuthorized"             => :forbidden,
-      "Catalog::OrderUncancelable"         => :unprocessable_entity,
-      "Catalog::TopologyError"             => :service_unavailable,
-      "Catalog::ApprovalError"             => :service_unavailable,
-      "Catalog::SourcesError"              => :service_unavailable,
-      "Catalog::RBACError"                 => :service_unavailable,
-      "Discard::DiscardError"              => :unprocessable_entity
-    )
-
     ActionDispatch::ExceptionWrapper.class_eval do
       # Until we get an updated version of ActionDispatch with the linked fix below,
       # this monkey patch is a temporary fix

--- a/config/initializers/custom_exception_mappings.rb
+++ b/config/initializers/custom_exception_mappings.rb
@@ -1,0 +1,20 @@
+############################################################################
+# This was moved out of config/application.rb due to the fact that
+# ActiveRecord loads its own rescue responses later in the application
+# initialization. Moving it to the initializers directory makes sure that
+# we always load our custom exceptions last.
+############################################################################
+
+ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
+  "ActiveRecord::RecordNotSaved"       => :bad_request,
+  "ActiveRecord::RecordInvalid"        => :bad_request,
+  "ActionController::ParameterMissing" => :bad_request,
+  "Catalog::InvalidParameter"          => :bad_request,
+  "Catalog::NotAuthorized"             => :forbidden,
+  "Catalog::OrderUncancelable"         => :bad_request,
+  "Catalog::TopologyError"             => :service_unavailable,
+  "Catalog::ApprovalError"             => :service_unavailable,
+  "Catalog::SourcesError"              => :service_unavailable,
+  "Catalog::RBACError"                 => :service_unavailable,
+  "Discard::DiscardError"              => :bad_request
+)

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -155,8 +155,8 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       }
@@ -194,8 +194,8 @@
           "404": {
             "description": "Portfolio not found."
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       },
@@ -239,8 +239,8 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       },
@@ -270,7 +270,7 @@
           "404": {
             "description": "Portfolio Not Found."
           },
-          "422": {
+          "400": {
             "description": "Failed to discard child portfolio items."
           }
         }
@@ -394,7 +394,7 @@
           "404": {
             "description": "The Portfolio Object was not found."
           },
-          "422": {
+          "400": {
             "description": "One or more of the RBAC groups was not found"
           }
         }
@@ -550,8 +550,8 @@
           "404": {
             "description": "Portfolio not found."
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         },
         "requestBody": {
@@ -750,8 +750,8 @@
           "404": {
             "description": "Tenant not found."
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       }
@@ -851,8 +851,8 @@
           "404": {
             "description": "Service Offering not found."
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         },
         "requestBody": {
@@ -1484,8 +1484,8 @@
           "404": {
             "description": "Order not found"
           },
-          "422": {
-            "$ref": "#/components/responses/UnprocessableEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       }
@@ -1523,8 +1523,8 @@
           "404": {
             "description": "Order not found."
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         },
         "requestBody": {
@@ -1675,8 +1675,8 @@
           "404": {
             "description": "Order item not found."
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         },
         "requestBody": {
@@ -1848,7 +1848,7 @@
           "404": {
             "description": "Portfolio Item not found"
           },
-          "422": {
+          "400": {
             "description": "Portfolio not found"
           },
           "500": {
@@ -2146,8 +2146,8 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       }
@@ -2180,8 +2180,8 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       },
@@ -2212,8 +2212,8 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       },
@@ -2239,8 +2239,8 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "422": {
-            "$ref": "#/components/responses/InvalidEntity"
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           }
         }
       }
@@ -2727,7 +2727,7 @@
       }
     },
     "responses": {
-      "InvalidEntity": {
+      "BadRequest": {
         "description": "The entity being created does not have either all the required parameters specified or the parameter value is invalid."
       },
       "Forbidden": {
@@ -2735,9 +2735,6 @@
       },
       "Unauthorized": {
         "description": "The caller is not authorized to access this resource."
-      },
-      "UnprocessableEntity": {
-        "description": "The entity is currently in a state that does not allow the requested action"
       }
     },
     "requestBodies": {

--- a/spec/requests/icons_spec.rb
+++ b/spec/requests/icons_spec.rb
@@ -100,8 +100,8 @@ describe "IconsRequests", :type => :request do
     context "when passing in improper parameters" do
       let(:params) { { :not_the_right_param => "whereami" } }
 
-      it "throws a 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "throws a 400" do
+        expect(response).to have_http_status(:bad_request)
       end
     end
 

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -54,11 +54,11 @@ describe "OrderRequests", :type => :request do
         allow(cancel_order).to receive(:process).and_raise(Catalog::OrderUncancelable.new("Order not cancelable"))
       end
 
-      it "returns a 422" do
+      it "returns a 400" do
         patch "/api/v1.0/orders/#{order.id}/cancel", :headers => default_headers
 
         expect(response.content_type).to eq("application/json")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:bad_request)
         expect(first_error_detail).to match(/Order not cancelable/)
       end
     end
@@ -131,8 +131,8 @@ describe "OrderRequests", :type => :request do
         delete "/#{api}/orders/#{order.id}", :headers => default_headers
       end
 
-      it "returns a 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "returns a 400" do
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "does not delete the order" do
@@ -153,8 +153,8 @@ describe "OrderRequests", :type => :request do
         delete "/#{api}/orders/#{order.id}", :headers => default_headers
       end
 
-      it "returns a 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "returns a 400" do
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "does not delete the order" do
@@ -208,8 +208,8 @@ describe "OrderRequests", :type => :request do
         post "/#{api}/orders/#{order.id}/restore", :headers => default_headers, :params => params
       end
 
-      it "returns a 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "returns a 400" do
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "does not restore the order" do
@@ -233,8 +233,8 @@ describe "OrderRequests", :type => :request do
         post "/#{api}/orders/#{order.id}/restore", :headers => default_headers, :params => params
       end
 
-      it "returns a 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "returns a 400" do
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "does not restore the order" do

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -326,8 +326,8 @@ describe "PortfolioItemRequests", :type => :request do
         copy_portfolio_item
       end
 
-      it 'returns a 422' do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it 'returns a 400' do
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -137,7 +137,7 @@ describe 'Portfolios API' do
       it 'reports errors when discarding child portfolio_items fails' do
         delete "#{api}/portfolios/#{portfolio_id}", :headers => default_headers, :params => valid_attributes
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -192,7 +192,7 @@ describe 'Portfolios API' do
       it 'reports errors when undiscarding the child portfolio_items fails' do
         post "#{api}/portfolios/#{portfolio_id}/undelete", :headers => default_headers, :params => params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:bad_request)
       end
     end
 
@@ -284,10 +284,10 @@ describe 'Portfolios API' do
         expect(json['name']).to eq valid_attributes[:name]
       end
 
-      it 'returns a status code 422 when trying to create with the same name' do
+      it 'returns a status code 400 when trying to create with the same name' do
         post "#{api}/portfolios", :params => valid_attributes, :headers => default_headers
 
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(400)
       end
 
       it 'stores the username in the owner column' do

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -62,8 +62,8 @@ describe 'Settings API', :type => :request do
         let(:params) { { :name => "icon", :value => "17" } }
         before { post "#{api}/settings", :headers => default_headers, :params => params }
 
-        it "returns a 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+        it "returns a 400" do
+          expect(response).to have_http_status(:bad_request)
         end
       end
     end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-744

Update our custom exceptions that mapped to `:unprocessable_entity` to use `:bad_request` instead and keep the OpenAPI spec up to date with these changes.