### PR TITLE
Handle discarded foreign_key refs in icon migration

### DIFF
--- a/app/services/catalog/create_icon.rb
+++ b/app/services/catalog/create_icon.rb
@@ -20,8 +20,7 @@ module Catalog
       @destination.icon&.discard
       @icon = Icon.create!(@params.merge(:image_id => image_id, :restore_to => @destination))
 
-      @destination.icon = @icon
-      @destination.save!
+      @destination.update!(:icon_id => @icon.id)
 
       self
     end

--- a/db/migrate/20191104171526_add_icon_id_to_portfolio_and_portfolio_item.rb
+++ b/db/migrate/20191104171526_add_icon_id_to_portfolio_and_portfolio_item.rb
@@ -8,7 +8,7 @@ class AddIconIdToPortfolioAndPortfolioItem < ActiveRecord::Migration[5.2]
     Icon.all.each do |icon|
       next if icon.iconable_type.nil?
 
-      iconable = icon.iconable_type.constantize.find(icon.iconable_id)
+      iconable = icon.iconable_type.constantize.with_discarded.find(icon.iconable_id)
 
       icon.update!(:restore_to =>  iconable)
       iconable.update!(:icon_id => icon.id)


### PR DESCRIPTION
The icon migration failed on CI due to a discarded portfolio_item that had an icon. This fixes that.